### PR TITLE
upgrade AudioSource usage in v3.1

### DIFF
--- a/taxi-game/assets/game.scene
+++ b/taxi-game/assets/game.scene
@@ -6,12 +6,11 @@
     "_native": "",
     "scene": {
       "__id__": 1
-    },
-    "asyncLoadAssets": false
+    }
   },
   {
     "__type__": "cc.Scene",
-    "_name": "",
+    "_name": "game",
     "_objFlags": 0,
     "_parent": null,
     "_children": [
@@ -22,34 +21,113 @@
         "__id__": 5
       },
       {
-        "__id__": 103
+        "__id__": 8
       },
       {
-        "__id__": 105
+        "__id__": 108
       },
       {
-        "__id__": 198
+        "__id__": 110
       },
       {
-        "__id__": 318
+        "__id__": 243
       },
       {
-        "__id__": 195
+        "__id__": 277
       },
       {
-        "__id__": 193
+        "__id__": 240
+      },
+      {
+        "__id__": 238
       }
     ],
     "_active": true,
     "_components": [],
     "_prefab": {
-      "__id__": 449
+      "__id__": 279
     },
     "autoReleaseAssets": false,
     "_globals": {
-      "__id__": 320
+      "__id__": 292
     },
     "_id": "b2a4621e-d814-4172-ae74-2d6536e94539"
+  },
+  {
+    "__type__": "cc.Node",
+    "_name": "GameRoot",
+    "_objFlags": 0,
+    "_parent": {
+      "__id__": 1
+    },
+    "_children": [],
+    "_active": true,
+    "_components": [
+      {
+        "__id__": 3
+      },
+      {
+        "__id__": 4
+      }
+    ],
+    "_prefab": null,
+    "_lpos": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "_lrot": {
+      "__type__": "cc.Quat",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 1
+    },
+    "_lscale": {
+      "__type__": "cc.Vec3",
+      "x": 1,
+      "y": 1,
+      "z": 1
+    },
+    "_layer": 1073741824,
+    "_euler": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "_id": "28nvbbmXxP847kk53PCeSW"
+  },
+  {
+    "__type__": "98dcdQl8GhEYLJRG8ap+Eh+",
+    "_name": "",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 2
+    },
+    "_enabled": true,
+    "__prefab": null,
+    "_audioSource": null,
+    "_id": "23WGvZjPpDXaS0PvJVLVK9"
+  },
+  {
+    "__type__": "cc.AudioSource",
+    "_name": "",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 2
+    },
+    "_enabled": true,
+    "__prefab": null,
+    "_clip": {
+      "__uuid__": "f55abddd-3f6d-4755-ba91-848685e6a115",
+      "__expectedType__": "cc.AudioClip"
+    },
+    "_loop": true,
+    "_playOnAwake": false,
+    "_volume": 1,
+    "_id": "05xZ6ju3JCRLcALy+XjWxh"
   },
   {
     "__type__": "cc.Node",
@@ -62,7 +140,7 @@
     "_active": true,
     "_components": [
       {
-        "__id__": 3
+        "__id__": 6
       }
     ],
     "_prefab": null,
@@ -99,7 +177,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 2
+      "__id__": 5
     },
     "_enabled": true,
     "__prefab": null,
@@ -113,13 +191,14 @@
     "_useColorTemperature": false,
     "_colorTemperature": 6550,
     "_staticSettings": {
-      "__id__": 4
+      "__id__": 7
     },
     "_illuminance": 65000,
     "_id": "597uMYCbhEtJQc0ffJlcgA"
   },
   {
     "__type__": "cc.StaticLightSettings",
+    "_baked": false,
     "_editorOnly": false,
     "_bakeable": false,
     "_castShadow": false
@@ -133,28 +212,28 @@
     },
     "_children": [
       {
-        "__id__": 6
+        "__id__": 9
       },
       {
-        "__id__": 8
+        "__id__": 11
       },
       {
-        "__id__": 325
+        "__id__": 102
       }
     ],
     "_active": true,
     "_components": [
       {
-        "__id__": 99
+        "__id__": 104
       },
       {
-        "__id__": 100
+        "__id__": 105
       },
       {
-        "__id__": 101
+        "__id__": 106
       },
       {
-        "__id__": 197
+        "__id__": 242
       }
     ],
     "_prefab": null,
@@ -191,13 +270,13 @@
     "_name": "UICamera_Canvas",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 5
+      "__id__": 8
     },
     "_children": [],
     "_active": true,
     "_components": [
       {
-        "__id__": 7
+        "__id__": 10
       }
     ],
     "_prefab": null,
@@ -234,7 +313,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 6
+      "__id__": 9
     },
     "_enabled": true,
     "__prefab": null,
@@ -275,35 +354,35 @@
     "_name": "loading",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 5
+      "__id__": 8
     },
     "_children": [
-      {
-        "__id__": 9
-      },
       {
         "__id__": 12
       },
       {
-        "__id__": 83
+        "__id__": 15
       },
       {
-        "__id__": 92
+        "__id__": 86
+      },
+      {
+        "__id__": 95
       }
     ],
     "_active": true,
     "_components": [
       {
-        "__id__": 95
-      },
-      {
-        "__id__": 96
-      },
-      {
-        "__id__": 97
-      },
-      {
         "__id__": 98
+      },
+      {
+        "__id__": 99
+      },
+      {
+        "__id__": 100
+      },
+      {
+        "__id__": 101
       }
     ],
     "_prefab": null,
@@ -340,16 +419,16 @@
     "_name": "bg",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 8
+      "__id__": 11
     },
     "_children": [],
     "_active": true,
     "_components": [
       {
-        "__id__": 10
+        "__id__": 13
       },
       {
-        "__id__": 11
+        "__id__": 14
       }
     ],
     "_prefab": null,
@@ -386,11 +465,10 @@
     "_name": "bg<UITransform>",
     "_objFlags": 0,
     "node": {
-      "__id__": 9
+      "__id__": 12
     },
     "_enabled": true,
     "__prefab": null,
-    "_priority": 0,
     "_contentSize": {
       "__type__": "cc.Size",
       "width": 720,
@@ -408,7 +486,7 @@
     "_name": "bg<Sprite>",
     "_objFlags": 0,
     "node": {
-      "__id__": 9
+      "__id__": 12
     },
     "_enabled": true,
     "__prefab": null,
@@ -424,7 +502,8 @@
       "a": 255
     },
     "_spriteFrame": {
-      "__uuid__": "433e09cb-3eeb-4a0b-819f-19373be6eef2@f9941"
+      "__uuid__": "433e09cb-3eeb-4a0b-819f-19373be6eef2@f9941",
+      "__expectedType__": "cc.SpriteFrame"
     },
     "_type": 0,
     "_fillType": 0,
@@ -446,29 +525,29 @@
     "_name": "loadingCar03",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 8
+      "__id__": 11
     },
     "_children": [
-      {
-        "__id__": 13
-      },
       {
         "__id__": 16
       },
       {
-        "__id__": 71
+        "__id__": 19
+      },
+      {
+        "__id__": 74
       }
     ],
     "_active": true,
     "_components": [
       {
-        "__id__": 80
+        "__id__": 83
       },
       {
-        "__id__": 81
+        "__id__": 84
       },
       {
-        "__id__": 82
+        "__id__": 85
       }
     ],
     "_prefab": null,
@@ -505,16 +584,16 @@
     "_name": "shadow",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 12
+      "__id__": 15
     },
     "_children": [],
     "_active": true,
     "_components": [
       {
-        "__id__": 14
+        "__id__": 17
       },
       {
-        "__id__": 15
+        "__id__": 18
       }
     ],
     "_prefab": null,
@@ -551,11 +630,10 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 13
+      "__id__": 16
     },
     "_enabled": true,
     "__prefab": null,
-    "_priority": 0,
     "_contentSize": {
       "__type__": "cc.Size",
       "width": 278,
@@ -573,7 +651,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 13
+      "__id__": 16
     },
     "_enabled": true,
     "__prefab": null,
@@ -589,7 +667,8 @@
       "a": 255
     },
     "_spriteFrame": {
-      "__uuid__": "374bcb3d-d0d0-4345-ae18-b9e46fe0950d@f9941"
+      "__uuid__": "374bcb3d-d0d0-4345-ae18-b9e46fe0950d@f9941",
+      "__expectedType__": "cc.SpriteFrame"
     },
     "_type": 0,
     "_fillType": 0,
@@ -611,19 +690,19 @@
     "_name": "car",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 12
+      "__id__": 15
     },
     "_children": [],
     "_active": true,
     "_components": [
       {
-        "__id__": 17
+        "__id__": 20
       },
       {
-        "__id__": 69
+        "__id__": 72
       },
       {
-        "__id__": 70
+        "__id__": 73
       }
     ],
     "_prefab": null,
@@ -660,102 +739,103 @@
     "_name": "car<ParticleSystem>",
     "_objFlags": 0,
     "node": {
-      "__id__": 16
+      "__id__": 19
     },
     "_enabled": true,
     "__prefab": null,
     "_materials": [
       {
-        "__uuid__": "f849cf4c-796a-4dc9-8ab0-53355d784ca1"
+        "__uuid__": "f849cf4c-796a-4dc9-8ab0-53355d784ca1",
+        "__expectedType__": "cc.Material"
       }
     ],
     "_visFlags": 0,
     "startColor": {
-      "__id__": 18
+      "__id__": 21
     },
     "scaleSpace": 1,
     "startSize3D": false,
     "startSizeX": {
-      "__id__": 19
+      "__id__": 22
     },
     "startSize": {
-      "__id__": 19
+      "__id__": 22
     },
     "startSizeY": {
-      "__id__": 20
+      "__id__": 23
     },
     "startSizeZ": {
-      "__id__": 21
+      "__id__": 24
     },
     "startSpeed": {
-      "__id__": 22
+      "__id__": 25
     },
     "startRotation3D": false,
     "startRotationX": {
-      "__id__": 23
-    },
-    "startRotationY": {
-      "__id__": 24
-    },
-    "startRotationZ": {
-      "__id__": 25
-    },
-    "startRotation": {
-      "__id__": 25
-    },
-    "startDelay": {
       "__id__": 26
     },
-    "startLifetime": {
+    "startRotationY": {
       "__id__": 27
+    },
+    "startRotationZ": {
+      "__id__": 28
+    },
+    "startRotation": {
+      "__id__": 28
+    },
+    "startDelay": {
+      "__id__": 29
+    },
+    "startLifetime": {
+      "__id__": 30
     },
     "duration": 5,
     "loop": true,
     "simulationSpeed": 1.2,
     "playOnAwake": true,
     "gravityModifier": {
-      "__id__": 28
+      "__id__": 31
     },
     "rateOverTime": {
-      "__id__": 29
+      "__id__": 32
     },
     "rateOverDistance": {
-      "__id__": 30
+      "__id__": 33
     },
     "bursts": [
       {
-        "__id__": 31
+        "__id__": 34
       }
     ],
     "_colorOverLifetimeModule": {
-      "__id__": 33
+      "__id__": 36
     },
     "_shapeModule": {
-      "__id__": 35
+      "__id__": 38
     },
     "_sizeOvertimeModule": {
-      "__id__": 37
+      "__id__": 40
     },
     "_velocityOvertimeModule": {
-      "__id__": 42
+      "__id__": 45
     },
     "_forceOvertimeModule": {
-      "__id__": 47
+      "__id__": 50
     },
     "_limitVelocityOvertimeModule": {
-      "__id__": 51
+      "__id__": 54
     },
     "_rotationOvertimeModule": {
-      "__id__": 56
+      "__id__": 59
     },
     "_textureAnimationModule": {
-      "__id__": 60
-    },
-    "_trailModule": {
       "__id__": 63
     },
+    "_trailModule": {
+      "__id__": 66
+    },
     "renderer": {
-      "__id__": 68
+      "__id__": 71
     },
     "enableCulling": false,
     "_prewarm": false,
@@ -852,7 +932,7 @@
     "_repeatCount": 1,
     "repeatInterval": 1,
     "count": {
-      "__id__": 32
+      "__id__": 35
     }
   },
   {
@@ -865,7 +945,7 @@
     "__type__": "cc.ColorOvertimeModule",
     "_enable": true,
     "color": {
-      "__id__": 34
+      "__id__": 37
     }
   },
   {
@@ -901,7 +981,7 @@
     "arcMode": 0,
     "arcSpread": 8,
     "arcSpeed": {
-      "__id__": 36
+      "__id__": 39
     },
     "length": 0,
     "boxThickness": {
@@ -942,16 +1022,16 @@
     "_enable": false,
     "separateAxes": false,
     "size": {
-      "__id__": 38
+      "__id__": 41
     },
     "x": {
-      "__id__": 39
+      "__id__": 42
     },
     "y": {
-      "__id__": 40
+      "__id__": 43
     },
     "z": {
-      "__id__": 41
+      "__id__": 44
     }
   },
   {
@@ -983,16 +1063,16 @@
     "__type__": "cc.VelocityOvertimeModule",
     "_enable": false,
     "x": {
-      "__id__": 43
+      "__id__": 46
     },
     "y": {
-      "__id__": 44
+      "__id__": 47
     },
     "z": {
-      "__id__": 45
+      "__id__": 48
     },
     "speedModifier": {
-      "__id__": 46
+      "__id__": 49
     },
     "space": 1
   },
@@ -1024,13 +1104,13 @@
     "__type__": "cc.ForceOvertimeModule",
     "_enable": false,
     "x": {
-      "__id__": 48
+      "__id__": 51
     },
     "y": {
-      "__id__": 49
+      "__id__": 52
     },
     "z": {
-      "__id__": 50
+      "__id__": 53
     },
     "space": 1
   },
@@ -1056,16 +1136,16 @@
     "__type__": "cc.LimitVelocityOvertimeModule",
     "_enable": false,
     "limitX": {
-      "__id__": 52
+      "__id__": 55
     },
     "limitY": {
-      "__id__": 53
+      "__id__": 56
     },
     "limitZ": {
-      "__id__": 54
+      "__id__": 57
     },
     "limit": {
-      "__id__": 55
+      "__id__": 58
     },
     "dampen": 3,
     "separateAxes": false,
@@ -1100,13 +1180,13 @@
     "_enable": false,
     "_separateAxes": false,
     "x": {
-      "__id__": 57
+      "__id__": 60
     },
     "y": {
-      "__id__": 58
+      "__id__": 61
     },
     "z": {
-      "__id__": 59
+      "__id__": 62
     }
   },
   {
@@ -1137,10 +1217,10 @@
     "_mode": 0,
     "animation": 0,
     "frameOverTime": {
-      "__id__": 61
+      "__id__": 64
     },
     "startFrame": {
-      "__id__": 62
+      "__id__": 65
     },
     "cycleCount": 0,
     "_flipU": 0,
@@ -1166,25 +1246,25 @@
     "_enable": false,
     "mode": 0,
     "lifeTime": {
-      "__id__": 64
+      "__id__": 67
     },
     "_minParticleDistance": 0.1,
     "existWithParticles": true,
     "textureMode": 0,
     "widthFromParticle": true,
     "widthRatio": {
-      "__id__": 65
+      "__id__": 68
     },
     "colorFromParticle": false,
     "colorOverTrail": {
-      "__id__": 66
+      "__id__": 69
     },
     "colorOvertime": {
-      "__id__": 67
+      "__id__": 70
     },
     "_space": 0,
     "_particleSystem": {
-      "__id__": 17
+      "__id__": 20
     }
   },
   {
@@ -1228,7 +1308,8 @@
     "_lengthScale": 1,
     "_mesh": null,
     "_mainTexture": {
-      "__uuid__": "fe262dd1-1451-449b-9fe9-61c6a1f6d1a6@6c48a"
+      "__uuid__": "fe262dd1-1451-449b-9fe9-61c6a1f6d1a6@6c48a",
+      "__expectedType__": "cc.Texture2D"
     },
     "_useGPU": false
   },
@@ -1237,7 +1318,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 16
+      "__id__": 19
     },
     "_enabled": true,
     "__prefab": null,
@@ -1248,11 +1329,10 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 16
+      "__id__": 19
     },
     "_enabled": true,
     "__prefab": null,
-    "_priority": 0,
     "_contentSize": {
       "__type__": "cc.Size",
       "width": 100,
@@ -1270,23 +1350,23 @@
     "_name": "loadingCar01",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 12
+      "__id__": 15
     },
     "_children": [
       {
-        "__id__": 72
+        "__id__": 75
       },
       {
-        "__id__": 75
+        "__id__": 78
       }
     ],
     "_active": true,
     "_components": [
       {
-        "__id__": 78
+        "__id__": 81
       },
       {
-        "__id__": 79
+        "__id__": 82
       }
     ],
     "_prefab": null,
@@ -1323,16 +1403,16 @@
     "_name": "loadingCar02",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 71
+      "__id__": 74
     },
     "_children": [],
     "_active": true,
     "_components": [
       {
-        "__id__": 73
+        "__id__": 76
       },
       {
-        "__id__": 74
+        "__id__": 77
       }
     ],
     "_prefab": null,
@@ -1369,11 +1449,10 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 72
+      "__id__": 75
     },
     "_enabled": true,
     "__prefab": null,
-    "_priority": 0,
     "_contentSize": {
       "__type__": "cc.Size",
       "width": 32,
@@ -1391,7 +1470,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 72
+      "__id__": 75
     },
     "_enabled": true,
     "__prefab": null,
@@ -1407,7 +1486,8 @@
       "a": 255
     },
     "_spriteFrame": {
-      "__uuid__": "33fa6394-37e5-4da8-b1ae-7eee42bd9ca6@f9941"
+      "__uuid__": "33fa6394-37e5-4da8-b1ae-7eee42bd9ca6@f9941",
+      "__expectedType__": "cc.SpriteFrame"
     },
     "_type": 0,
     "_fillType": 0,
@@ -1429,16 +1509,16 @@
     "_name": "loadingCar03",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 71
+      "__id__": 74
     },
     "_children": [],
     "_active": true,
     "_components": [
       {
-        "__id__": 76
+        "__id__": 79
       },
       {
-        "__id__": 77
+        "__id__": 80
       }
     ],
     "_prefab": null,
@@ -1475,11 +1555,10 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 75
+      "__id__": 78
     },
     "_enabled": true,
     "__prefab": null,
-    "_priority": 0,
     "_contentSize": {
       "__type__": "cc.Size",
       "width": 32,
@@ -1497,7 +1576,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 75
+      "__id__": 78
     },
     "_enabled": true,
     "__prefab": null,
@@ -1513,7 +1592,8 @@
       "a": 255
     },
     "_spriteFrame": {
-      "__uuid__": "33fa6394-37e5-4da8-b1ae-7eee42bd9ca6@f9941"
+      "__uuid__": "33fa6394-37e5-4da8-b1ae-7eee42bd9ca6@f9941",
+      "__expectedType__": "cc.SpriteFrame"
     },
     "_type": 0,
     "_fillType": 0,
@@ -1535,11 +1615,10 @@
     "_name": "loadingCar01<UITransform>",
     "_objFlags": 0,
     "node": {
-      "__id__": 71
+      "__id__": 74
     },
     "_enabled": true,
     "__prefab": null,
-    "_priority": 0,
     "_contentSize": {
       "__type__": "cc.Size",
       "width": 195,
@@ -1557,7 +1636,7 @@
     "_name": "loadingCar01<Sprite>",
     "_objFlags": 0,
     "node": {
-      "__id__": 71
+      "__id__": 74
     },
     "_enabled": true,
     "__prefab": null,
@@ -1573,7 +1652,8 @@
       "a": 255
     },
     "_spriteFrame": {
-      "__uuid__": "0de65add-2596-4acf-a421-416e2edd85a4@f9941"
+      "__uuid__": "0de65add-2596-4acf-a421-416e2edd85a4@f9941",
+      "__expectedType__": "cc.SpriteFrame"
     },
     "_type": 0,
     "_fillType": 0,
@@ -1595,11 +1675,10 @@
     "_name": "loadingCar03<UITransform>",
     "_objFlags": 0,
     "node": {
-      "__id__": 12
+      "__id__": 15
     },
     "_enabled": true,
     "__prefab": null,
-    "_priority": 0,
     "_contentSize": {
       "__type__": "cc.Size",
       "width": 144,
@@ -1617,7 +1696,7 @@
     "_name": "loadingCar03<Sprite>",
     "_objFlags": 0,
     "node": {
-      "__id__": 12
+      "__id__": 15
     },
     "_enabled": true,
     "__prefab": null,
@@ -1633,7 +1712,8 @@
       "a": 255
     },
     "_spriteFrame": {
-      "__uuid__": "14bc4439-7f82-4f33-9d15-c956ad5cdcd3@f9941"
+      "__uuid__": "14bc4439-7f82-4f33-9d15-c956ad5cdcd3@f9941",
+      "__expectedType__": "cc.SpriteFrame"
     },
     "_type": 0,
     "_fillType": 0,
@@ -1655,18 +1735,20 @@
     "_name": "loadingCar03<Animation>",
     "_objFlags": 0,
     "node": {
-      "__id__": 12
+      "__id__": 15
     },
     "_enabled": true,
     "__prefab": null,
     "playOnLoad": true,
     "_clips": [
       {
-        "__uuid__": "190285d7-5314-48d6-83ff-73fa2accc0e7"
+        "__uuid__": "190285d7-5314-48d6-83ff-73fa2accc0e7",
+        "__expectedType__": "cc.AnimationClip"
       }
     ],
     "_defaultClip": {
-      "__uuid__": "190285d7-5314-48d6-83ff-73fa2accc0e7"
+      "__uuid__": "190285d7-5314-48d6-83ff-73fa2accc0e7",
+      "__expectedType__": "cc.AnimationClip"
     },
     "_id": "f6gXBrKQVAJLwRtpM2rXyW"
   },
@@ -1675,23 +1757,23 @@
     "_name": "progress",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 8
+      "__id__": 11
     },
     "_children": [
       {
-        "__id__": 84
+        "__id__": 87
       },
       {
-        "__id__": 87
+        "__id__": 90
       }
     ],
     "_active": true,
     "_components": [
       {
-        "__id__": 90
+        "__id__": 93
       },
       {
-        "__id__": 91
+        "__id__": 94
       }
     ],
     "_prefab": null,
@@ -1728,22 +1810,22 @@
     "_name": "txt",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 83
+      "__id__": 86
     },
     "_children": [],
     "_active": true,
     "_components": [
       {
-        "__id__": 85
+        "__id__": 88
       },
       {
-        "__id__": 86
+        "__id__": 89
       }
     ],
     "_prefab": null,
     "_lpos": {
       "__type__": "cc.Vec3",
-      "x": 25.438,
+      "x": 32.215,
       "y": 0,
       "z": 0
     },
@@ -1774,11 +1856,10 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 84
+      "__id__": 87
     },
     "_enabled": true,
     "__prefab": null,
-    "_priority": 0,
     "_contentSize": {
       "__type__": "cc.Size",
       "width": 100,
@@ -1796,7 +1877,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 84
+      "__id__": 87
     },
     "_enabled": true,
     "__prefab": null,
@@ -1834,16 +1915,16 @@
     "_name": "tip",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 83
+      "__id__": 86
     },
     "_children": [],
     "_active": true,
     "_components": [
       {
-        "__id__": 88
+        "__id__": 91
       },
       {
-        "__id__": 89
+        "__id__": 92
       }
     ],
     "_prefab": null,
@@ -1880,11 +1961,10 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 87
+      "__id__": 90
     },
     "_enabled": true,
     "__prefab": null,
-    "_priority": 0,
     "_contentSize": {
       "__type__": "cc.Size",
       "width": 35.57,
@@ -1902,7 +1982,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 87
+      "__id__": 90
     },
     "_enabled": true,
     "__prefab": null,
@@ -1940,11 +2020,10 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 83
+      "__id__": 86
     },
     "_enabled": true,
     "__prefab": null,
-    "_priority": 0,
     "_contentSize": {
       "__type__": "cc.Size",
       "width": 135.57,
@@ -1962,7 +2041,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 83
+      "__id__": 86
     },
     "_enabled": true,
     "__prefab": null,
@@ -1993,16 +2072,16 @@
     "_name": "tips",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 8
+      "__id__": 11
     },
     "_children": [],
     "_active": true,
     "_components": [
       {
-        "__id__": 93
+        "__id__": 96
       },
       {
-        "__id__": 94
+        "__id__": 97
       }
     ],
     "_prefab": null,
@@ -2039,11 +2118,10 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 92
+      "__id__": 95
     },
     "_enabled": true,
     "__prefab": null,
-    "_priority": 0,
     "_contentSize": {
       "__type__": "cc.Size",
       "width": 186.67,
@@ -2061,7 +2139,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 92
+      "__id__": 95
     },
     "_enabled": true,
     "__prefab": null,
@@ -2099,11 +2177,10 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 8
+      "__id__": 11
     },
     "_enabled": true,
     "__prefab": null,
-    "_priority": 100,
     "_contentSize": {
       "__type__": "cc.Size",
       "width": 640,
@@ -2121,7 +2198,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 8
+      "__id__": 11
     },
     "_enabled": true,
     "__prefab": null,
@@ -2150,7 +2227,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 8
+      "__id__": 11
     },
     "_enabled": true,
     "__prefab": null,
@@ -2161,28 +2238,111 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 8
+      "__id__": 11
     },
     "_enabled": true,
     "__prefab": null,
     "progressLabel": {
-      "__id__": 86
+      "__id__": 89
     },
     "tipLabel": {
-      "__id__": 94
+      "__id__": 97
     },
     "_id": "69r3fl5WRCk4AyxqXdZMZW"
+  },
+  {
+    "__type__": "cc.Node",
+    "_name": "UICamera_Canvas",
+    "_objFlags": 0,
+    "_parent": {
+      "__id__": 8
+    },
+    "_children": [],
+    "_active": true,
+    "_components": [
+      {
+        "__id__": 103
+      }
+    ],
+    "_prefab": null,
+    "_lpos": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 1000
+    },
+    "_lrot": {
+      "__type__": "cc.Quat",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 1
+    },
+    "_lscale": {
+      "__type__": "cc.Vec3",
+      "x": 1,
+      "y": 1,
+      "z": 1
+    },
+    "_layer": 524288,
+    "_euler": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "_id": "588pllofdKVbpQbOPRu35n"
+  },
+  {
+    "__type__": "cc.Camera",
+    "_name": "",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 102
+    },
+    "_enabled": true,
+    "__prefab": null,
+    "_projection": 0,
+    "_priority": 1073741824,
+    "_fov": 45,
+    "_fovAxis": 0,
+    "_orthoHeight": 480,
+    "_near": 1,
+    "_far": 2000,
+    "_color": {
+      "__type__": "cc.Color",
+      "r": 0,
+      "g": 0,
+      "b": 0,
+      "a": 255
+    },
+    "_depth": 1,
+    "_stencil": 0,
+    "_clearFlags": 6,
+    "_rect": {
+      "__type__": "cc.Rect",
+      "x": 0,
+      "y": 0,
+      "width": 1,
+      "height": 1
+    },
+    "_aperture": 19,
+    "_shutter": 7,
+    "_iso": 0,
+    "_screenScale": 1,
+    "_visibility": 42467328,
+    "_targetTexture": null,
+    "_id": "bdFB2kAcNIU6nkiA1oWkvK"
   },
   {
     "__type__": "cc.UITransform",
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 5
+      "__id__": 8
     },
     "_enabled": true,
     "__prefab": null,
-    "_priority": 0,
     "_contentSize": {
       "__type__": "cc.Size",
       "width": 640,
@@ -2200,12 +2360,12 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 5
+      "__id__": 8
     },
     "_enabled": true,
     "__prefab": null,
     "_cameraComponent": {
-      "__id__": 326
+      "__id__": 103
     },
     "_alignCanvasWithScreen": true,
     "_id": "ac2d7qSghObK4uZWfKo7o4"
@@ -2215,21 +2375,21 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 5
+      "__id__": 8
     },
     "_enabled": true,
     "__prefab": null,
     "mapManager": {
-      "__id__": 102
+      "__id__": 107
     },
     "carManager": {
-      "__id__": 104
+      "__id__": 109
     },
     "group": {
-      "__id__": 195
+      "__id__": 240
     },
     "loadingUI": {
-      "__id__": 98
+      "__id__": 101
     },
     "_id": "60qLW8TIxHK5Gl8u+udd72"
   },
@@ -2238,7 +2398,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 103
+      "__id__": 108
     },
     "_enabled": true,
     "__prefab": null,
@@ -2255,7 +2415,7 @@
     "_active": true,
     "_components": [
       {
-        "__id__": 102
+        "__id__": 107
       }
     ],
     "_prefab": null,
@@ -2292,13 +2452,13 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 105
+      "__id__": 110
     },
     "_enabled": true,
     "__prefab": null,
     "mainCar": null,
     "camera": {
-      "__id__": 193
+      "__id__": 238
     },
     "cameraPos": {
       "__type__": "cc.Vec3",
@@ -2318,13 +2478,13 @@
     },
     "_children": [
       {
-        "__id__": 106
+        "__id__": 111
       }
     ],
     "_active": true,
     "_components": [
       {
-        "__id__": 104
+        "__id__": 109
       }
     ],
     "_prefab": null,
@@ -2360,926 +2520,394 @@
     "__type__": "cc.Node",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 105
+      "__id__": 110
     },
     "_prefab": {
-      "__id__": 192
+      "__id__": 112
     },
     "_id": "da5CaKo1pNSYAvornfmzPz"
   },
   {
-    "__type__": "cc.Node",
-    "_name": "RootNode",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 106
+    "__type__": "cc.PrefabInfo",
+    "root": {
+      "__id__": 111
     },
-    "_children": [
+    "asset": {
+      "__uuid__": "7470a7d3-6662-4190-be25-ffeffe754a5c",
+      "__expectedType__": "cc.Prefab"
+    },
+    "fileId": "8di29+BXJCNLrma/FTq1Lc",
+    "instance": {
+      "__id__": 113
+    }
+  },
+  {
+    "__type__": "cc.PrefabInstance",
+    "fileId": "d02UgKoCFK+ZX2ElodxZEe",
+    "prefabRootNode": null,
+    "mountedChildren": [],
+    "mountedComponents": [],
+    "propertyOverrides": [
       {
-        "__id__": 108
+        "__id__": 114
       },
       {
-        "__id__": 112
-      },
-      {
-        "__id__": 116
+        "__id__": 117
       },
       {
         "__id__": 120
       },
       {
-        "__id__": 124
+        "__id__": 123
       },
       {
-        "__id__": 128
-      }
-    ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 132
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0,
-      "y": 0,
-      "z": 0
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": 0,
-      "y": 0,
-      "z": 0,
-      "w": 1
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 1,
-      "z": 1
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": 0,
-      "y": 0,
-      "z": 0
-    },
-    "_id": "d6bAwLi4pElbFs1SVkR54+"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "chuzu02",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 107
-    },
-    "_children": [],
-    "_active": true,
-    "_components": [
-      {
-        "__id__": 109
-      }
-    ],
-    "_prefab": {
-      "__id__": 111
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0,
-      "y": 0,
-      "z": 0
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": 0.7009090756500369,
-      "y": -6.127542185364965e-8,
-      "z": -6.235434546696067e-8,
-      "w": 0.7132506345397831
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": -6.23844623565674,
-      "y": -6.23844623565674,
-      "z": -6.0649094581604
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": 88.99996969132904,
-      "y": -7.877938247119141e-13,
-      "z": -0.000010017912168977351
-    },
-    "_id": "587OKPk8VKza7qDPx6eb55"
-  },
-  {
-    "__type__": "cc.MeshRenderer",
-    "_name": "",
-    "_objFlags": 0,
-    "node": {
-      "__id__": 108
-    },
-    "_enabled": true,
-    "__prefab": {
-      "__id__": 327
-    },
-    "_materials": [
-      {
-        "__uuid__": "b14e9a6e-2a1d-46b9-be38-5ef6a083e5af@e3cf8"
-      }
-    ],
-    "_visFlags": 0,
-    "lightmapSettings": {
-      "__id__": 110
-    },
-    "_mesh": {
-      "__uuid__": "b14e9a6e-2a1d-46b9-be38-5ef6a083e5af@050ef"
-    },
-    "_shadowCastingMode": 0,
-    "_shadowReceivingMode": 1,
-    "_enableMorph": true,
-    "_id": "1359Qk2EZKVq8+z3uvsQ+W"
-  },
-  {
-    "__type__": "cc.ModelLightmapSettings",
-    "texture": null,
-    "uvParam": {
-      "__type__": "cc.Vec4",
-      "x": 0,
-      "y": 0,
-      "z": 0,
-      "w": 0
-    },
-    "_bakeable": false,
-    "_castShadow": false,
-    "_receiveShadow": false,
-    "_recieveShadow": false,
-    "_lightmapSize": 64
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 106
-    },
-    "asset": {
-      "__uuid__": "7470a7d3-6662-4190-be25-ffeffe754a5c"
-    },
-    "fileId": "966z+9ma1Nt5Ybs0krYE3x"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "tyre4",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 107
-    },
-    "_children": [],
-    "_active": true,
-    "_components": [
-      {
-        "__id__": 113
-      }
-    ],
-    "_prefab": {
-      "__id__": 115
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.237070500850677,
-      "y": 0.08955068141222,
-      "z": -0.338036328554153
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": 0.7071066619772446,
-      "y": 6.181724038536681e-8,
-      "z": 9.334143149262265e-15,
-      "w": 0.7071069003958277
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": -6.23844623565674,
-      "y": -6.23844623565674,
-      "z": -6.0649094581604
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": 89.99998068130715,
-      "y": 0.00000500895640060331,
-      "z": 0.000005008956224372127
-    },
-    "_id": "6e7/kCychLzrKoD6B34sBt"
-  },
-  {
-    "__type__": "cc.MeshRenderer",
-    "_name": "",
-    "_objFlags": 0,
-    "node": {
-      "__id__": 112
-    },
-    "_enabled": true,
-    "__prefab": {
-      "__id__": 328
-    },
-    "_materials": [
-      {
-        "__uuid__": "b14e9a6e-2a1d-46b9-be38-5ef6a083e5af@e3cf8"
-      }
-    ],
-    "_visFlags": 0,
-    "lightmapSettings": {
-      "__id__": 114
-    },
-    "_mesh": {
-      "__uuid__": "b14e9a6e-2a1d-46b9-be38-5ef6a083e5af@801a3"
-    },
-    "_shadowCastingMode": 0,
-    "_shadowReceivingMode": 1,
-    "_enableMorph": true,
-    "_id": "ba3krU0J9OA5LcA6x1lHQy"
-  },
-  {
-    "__type__": "cc.ModelLightmapSettings",
-    "texture": null,
-    "uvParam": {
-      "__type__": "cc.Vec4",
-      "x": 0,
-      "y": 0,
-      "z": 0,
-      "w": 0
-    },
-    "_bakeable": false,
-    "_castShadow": false,
-    "_receiveShadow": false,
-    "_recieveShadow": false,
-    "_lightmapSize": 64
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 106
-    },
-    "asset": {
-      "__uuid__": "7470a7d3-6662-4190-be25-ffeffe754a5c"
-    },
-    "fileId": "93onMUVdtLYZvgOaiPrRHT"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "tyre1",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 107
-    },
-    "_children": [],
-    "_active": true,
-    "_components": [
-      {
-        "__id__": 117
-      }
-    ],
-    "_prefab": {
-      "__id__": 119
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": -0.237846583127975,
-      "y": 0.0895507112145424,
-      "z": 0.291596740484238
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": 0.707106602372586,
-      "y": 6.181724038536571e-8,
-      "z": 1.4738378616658607e-14,
-      "w": 0.7071069600004611
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": -6.23844623565674,
-      "y": -6.23844623565674,
-      "z": -6.0649094581604
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": 89.99997102196079,
-      "y": 0.000005008956384929839,
-      "z": 0.000005008956240045592
-    },
-    "_id": "9etvdbIWNGYbYQK2vQGZqC"
-  },
-  {
-    "__type__": "cc.MeshRenderer",
-    "_name": "",
-    "_objFlags": 0,
-    "node": {
-      "__id__": 116
-    },
-    "_enabled": true,
-    "__prefab": {
-      "__id__": 329
-    },
-    "_materials": [
-      {
-        "__uuid__": "b14e9a6e-2a1d-46b9-be38-5ef6a083e5af@e3cf8"
-      }
-    ],
-    "_visFlags": 0,
-    "lightmapSettings": {
-      "__id__": 118
-    },
-    "_mesh": {
-      "__uuid__": "b14e9a6e-2a1d-46b9-be38-5ef6a083e5af@8c383"
-    },
-    "_shadowCastingMode": 0,
-    "_shadowReceivingMode": 1,
-    "_enableMorph": true,
-    "_id": "59UHiE9gpJr7rhVfE2ZdMY"
-  },
-  {
-    "__type__": "cc.ModelLightmapSettings",
-    "texture": null,
-    "uvParam": {
-      "__type__": "cc.Vec4",
-      "x": 0,
-      "y": 0,
-      "z": 0,
-      "w": 0
-    },
-    "_bakeable": false,
-    "_castShadow": false,
-    "_receiveShadow": false,
-    "_recieveShadow": false,
-    "_lightmapSize": 64
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 106
-    },
-    "asset": {
-      "__uuid__": "7470a7d3-6662-4190-be25-ffeffe754a5c"
-    },
-    "fileId": "84HLuKg01NKYh7CzrKYh5a"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "tyre2",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 107
-    },
-    "_children": [],
-    "_active": true,
-    "_components": [
-      {
-        "__id__": 121
-      }
-    ],
-    "_prefab": {
-      "__id__": 123
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.237070590257645,
-      "y": 0.089550644159317,
-      "z": 0.291596621274948
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": 0.707106602372586,
-      "y": 6.181724038536571e-8,
-      "z": 1.4738378616658607e-14,
-      "w": 0.7071069600004611
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": -6.23844623565674,
-      "y": -6.23844623565674,
-      "z": -6.0649094581604
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": 89.99997102196079,
-      "y": 0.000005008956384929839,
-      "z": 0.000005008956240045592
-    },
-    "_id": "93coYLkYJGTrbVPvxWTeHe"
-  },
-  {
-    "__type__": "cc.MeshRenderer",
-    "_name": "",
-    "_objFlags": 0,
-    "node": {
-      "__id__": 120
-    },
-    "_enabled": true,
-    "__prefab": {
-      "__id__": 330
-    },
-    "_materials": [
-      {
-        "__uuid__": "b14e9a6e-2a1d-46b9-be38-5ef6a083e5af@e3cf8"
-      }
-    ],
-    "_visFlags": 0,
-    "lightmapSettings": {
-      "__id__": 122
-    },
-    "_mesh": {
-      "__uuid__": "b14e9a6e-2a1d-46b9-be38-5ef6a083e5af@4166c"
-    },
-    "_shadowCastingMode": 0,
-    "_shadowReceivingMode": 1,
-    "_enableMorph": true,
-    "_id": "5a88mZPOBPv4fHTfgfQcyh"
-  },
-  {
-    "__type__": "cc.ModelLightmapSettings",
-    "texture": null,
-    "uvParam": {
-      "__type__": "cc.Vec4",
-      "x": 0,
-      "y": 0,
-      "z": 0,
-      "w": 0
-    },
-    "_bakeable": false,
-    "_castShadow": false,
-    "_receiveShadow": false,
-    "_recieveShadow": false,
-    "_lightmapSize": 64
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 106
-    },
-    "asset": {
-      "__uuid__": "7470a7d3-6662-4190-be25-ffeffe754a5c"
-    },
-    "fileId": "f5KcjjM3xO7o4wB3YsZdW6"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "tyre3",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 107
-    },
-    "_children": [],
-    "_active": true,
-    "_components": [
-      {
-        "__id__": 125
-      }
-    ],
-    "_prefab": {
-      "__id__": 127
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": -0.237846672534943,
-      "y": 0.089550718665123,
-      "z": -0.338036239147186
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": 0.707106602372586,
-      "y": 6.181724038536571e-8,
-      "z": 1.4738378616658607e-14,
-      "w": 0.7071069600004611
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": -6.23844623565674,
-      "y": -6.23844623565674,
-      "z": -6.0649094581604
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": 89.99997102196079,
-      "y": 0.000005008956384929839,
-      "z": 0.000005008956240045592
-    },
-    "_id": "fcrpi7vAFJNaEkuX0pjZKj"
-  },
-  {
-    "__type__": "cc.MeshRenderer",
-    "_name": "",
-    "_objFlags": 0,
-    "node": {
-      "__id__": 124
-    },
-    "_enabled": true,
-    "__prefab": {
-      "__id__": 331
-    },
-    "_materials": [
-      {
-        "__uuid__": "b14e9a6e-2a1d-46b9-be38-5ef6a083e5af@e3cf8"
-      }
-    ],
-    "_visFlags": 0,
-    "lightmapSettings": {
-      "__id__": 126
-    },
-    "_mesh": {
-      "__uuid__": "b14e9a6e-2a1d-46b9-be38-5ef6a083e5af@6726b"
-    },
-    "_shadowCastingMode": 0,
-    "_shadowReceivingMode": 1,
-    "_enableMorph": true,
-    "_id": "25hiGIDlhNkqYTYw0HU3eu"
-  },
-  {
-    "__type__": "cc.ModelLightmapSettings",
-    "texture": null,
-    "uvParam": {
-      "__type__": "cc.Vec4",
-      "x": 0,
-      "y": 0,
-      "z": 0,
-      "w": 0
-    },
-    "_bakeable": false,
-    "_castShadow": false,
-    "_receiveShadow": false,
-    "_recieveShadow": false,
-    "_lightmapSize": 64
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 106
-    },
-    "asset": {
-      "__uuid__": "7470a7d3-6662-4190-be25-ffeffe754a5c"
-    },
-    "fileId": "e8uApGHQtENaM2D2bkfypy"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "light1",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 107
-    },
-    "_children": [],
-    "_active": true,
-    "_components": [
+        "__id__": 126
+      },
       {
         "__id__": 129
-      }
-    ],
-    "_prefab": {
-      "__id__": 131
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.0064697596244514,
-      "y": 0.227475345134735,
-      "z": 0.500026047229767
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": 0.7009090756500369,
-      "y": -6.127541474822228e-8,
-      "z": -6.235435257238804e-8,
-      "w": 0.7132506345397831
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": -6.23844623565674,
-      "y": -6.23844623565674,
-      "z": -6.06491041183472
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": 88.99996969132904,
-      "y": 3.636461224375672e-13,
-      "z": -0.000010017912179026118
-    },
-    "_id": "d86MgGocxOEpbKwcx6+RCE"
-  },
-  {
-    "__type__": "cc.MeshRenderer",
-    "_name": "",
-    "_objFlags": 0,
-    "node": {
-      "__id__": 128
-    },
-    "_enabled": true,
-    "__prefab": {
-      "__id__": 332
-    },
-    "_materials": [
+      },
       {
-        "__uuid__": "b14e9a6e-2a1d-46b9-be38-5ef6a083e5af@e3cf8"
-      }
-    ],
-    "_visFlags": 0,
-    "lightmapSettings": {
-      "__id__": 130
-    },
-    "_mesh": {
-      "__uuid__": "b14e9a6e-2a1d-46b9-be38-5ef6a083e5af@14b6a"
-    },
-    "_shadowCastingMode": 0,
-    "_shadowReceivingMode": 1,
-    "_enableMorph": true,
-    "_id": "9ejx3uZDtFM5TUgMwx48tW"
-  },
-  {
-    "__type__": "cc.ModelLightmapSettings",
-    "texture": null,
-    "uvParam": {
-      "__type__": "cc.Vec4",
-      "x": 0,
-      "y": 0,
-      "z": 0,
-      "w": 0
-    },
-    "_bakeable": false,
-    "_castShadow": false,
-    "_receiveShadow": false,
-    "_recieveShadow": false,
-    "_lightmapSize": 64
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 106
-    },
-    "asset": {
-      "__uuid__": "7470a7d3-6662-4190-be25-ffeffe754a5c"
-    },
-    "fileId": "c1y+sHWRBCYrFCI36NXMdA"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 106
-    },
-    "asset": {
-      "__uuid__": "7470a7d3-6662-4190-be25-ffeffe754a5c"
-    },
-    "fileId": "9c7NJn60JLkIN6nisMASvb"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "light",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 106
-    },
-    "_children": [],
-    "_active": true,
-    "_components": [
+        "__id__": 132
+      },
       {
-        "__id__": 134
-      }
-    ],
-    "_prefab": {
-      "__id__": 136
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.011,
-      "y": 0.158,
-      "z": -0.905
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": -0.7071067811865475,
-      "y": 0,
-      "z": 0,
-      "w": 0.7071067811865476
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 0.8,
-      "y": 0.8,
-      "z": 1
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": -90,
-      "y": 0,
-      "z": 0
-    },
-    "_id": "afr89c5k1FiJYcvJMHH3D4"
-  },
-  {
-    "__type__": "cc.MeshRenderer",
-    "_name": "Quad<MeshRenderer>",
-    "_objFlags": 0,
-    "node": {
-      "__id__": 133
-    },
-    "_enabled": true,
-    "__prefab": {
-      "__id__": 333
-    },
-    "_materials": [
-      {
-        "__uuid__": "19614e65-f784-493c-96a6-2dd3d0d0ef70"
-      }
-    ],
-    "_visFlags": 0,
-    "lightmapSettings": {
-      "__id__": 135
-    },
-    "_mesh": {
-      "__uuid__": "1263d74c-8167-4928-91a6-4e2672411f47@fc873"
-    },
-    "_shadowCastingMode": 0,
-    "_shadowReceivingMode": 1,
-    "_enableMorph": true,
-    "_id": "fbk5Y30xtETq3O1ThT0R/Z"
-  },
-  {
-    "__type__": "cc.ModelLightmapSettings",
-    "texture": null,
-    "uvParam": {
-      "__type__": "cc.Vec4",
-      "x": 0,
-      "y": 0,
-      "z": 0,
-      "w": 0
-    },
-    "_bakeable": false,
-    "_castShadow": false,
-    "_receiveShadow": false,
-    "_recieveShadow": false,
-    "_lightmapSize": 64
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 106
-    },
-    "asset": {
-      "__uuid__": "7470a7d3-6662-4190-be25-ffeffe754a5c"
-    },
-    "fileId": "30cPaTbX1LAa/bZsURkVn7"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "gas",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 106
-    },
-    "_children": [],
-    "_active": true,
-    "_components": [
+        "__id__": 135
+      },
       {
         "__id__": 138
+      },
+      {
+        "__id__": 141
+      },
+      {
+        "__id__": 143
+      },
+      {
+        "__id__": 146
+      },
+      {
+        "__id__": 149
+      },
+      {
+        "__id__": 152
+      },
+      {
+        "__id__": 155
+      },
+      {
+        "__id__": 158
+      },
+      {
+        "__id__": 161
+      },
+      {
+        "__id__": 163
+      },
+      {
+        "__id__": 166
+      },
+      {
+        "__id__": 169
+      },
+      {
+        "__id__": 172
+      },
+      {
+        "__id__": 175
+      },
+      {
+        "__id__": 178
+      },
+      {
+        "__id__": 182
+      },
+      {
+        "__id__": 186
+      },
+      {
+        "__id__": 193
+      },
+      {
+        "__id__": 200
+      },
+      {
+        "__id__": 206
+      },
+      {
+        "__id__": 213
+      },
+      {
+        "__id__": 219
+      },
+      {
+        "__id__": 224
+      },
+      {
+        "__id__": 231
+      },
+      {
+        "__id__": 234
+      },
+      {
+        "__id__": 236
       }
     ],
-    "_prefab": {
-      "__id__": 188
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0,
-      "y": 0.097,
-      "z": 0.714
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": 1,
-      "y": 0,
-      "z": 0,
-      "w": 6.123233995736766e-17
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 1,
-      "z": 1
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": 180,
-      "y": 0,
-      "z": 0
-    },
-    "_id": "8fXt4pqJRIR6K9pUqds9pA"
+    "removedComponents": []
   },
   {
-    "__type__": "cc.ParticleSystem",
-    "_name": "",
-    "_objFlags": 0,
-    "node": {
-      "__id__": 137
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 115
     },
-    "_enabled": true,
-    "__prefab": {
-      "__id__": 334
-    },
-    "_materials": [
-      {
-        "__uuid__": "f849cf4c-796a-4dc9-8ab0-53355d784ca1"
-      }
+    "propertyPath": [
+      "lightmapSettings"
     ],
-    "_visFlags": 0,
-    "startColor": {
-      "__id__": 139
+    "value": {
+      "__id__": 116
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "9bXXwPtfJBS7AVvRYX3GGA"
+    ]
+  },
+  {
+    "__type__": "cc.ModelLightmapSettings",
+    "texture": null,
+    "uvParam": {
+      "__type__": "cc.Vec4",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 0
     },
-    "scaleSpace": 1,
-    "startSize3D": false,
-    "startSizeX": {
-      "__id__": 140
+    "_bakeable": false,
+    "_castShadow": false,
+    "_receiveShadow": false,
+    "_recieveShadow": false,
+    "_lightmapSize": 64
+  },
+  {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 118
     },
-    "startSize": {
-      "__id__": 140
+    "propertyPath": [
+      "lightmapSettings"
+    ],
+    "value": {
+      "__id__": 119
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "f3kBbd969BXb+kpZKmY2KS"
+    ]
+  },
+  {
+    "__type__": "cc.ModelLightmapSettings",
+    "texture": null,
+    "uvParam": {
+      "__type__": "cc.Vec4",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 0
     },
-    "startSizeY": {
-      "__id__": 141
+    "_bakeable": false,
+    "_castShadow": false,
+    "_receiveShadow": false,
+    "_recieveShadow": false,
+    "_lightmapSize": 64
+  },
+  {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 121
     },
-    "startSizeZ": {
-      "__id__": 142
+    "propertyPath": [
+      "lightmapSettings"
+    ],
+    "value": {
+      "__id__": 122
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "ccznVDYfxC7oNW7gesXGx2"
+    ]
+  },
+  {
+    "__type__": "cc.ModelLightmapSettings",
+    "texture": null,
+    "uvParam": {
+      "__type__": "cc.Vec4",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 0
     },
-    "startSpeed": {
-      "__id__": 143
+    "_bakeable": false,
+    "_castShadow": false,
+    "_receiveShadow": false,
+    "_recieveShadow": false,
+    "_lightmapSize": 64
+  },
+  {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 124
     },
-    "startRotation3D": false,
-    "startRotationX": {
-      "__id__": 144
+    "propertyPath": [
+      "lightmapSettings"
+    ],
+    "value": {
+      "__id__": 125
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "43fXX9ZQJM9IzG45k3BGZa"
+    ]
+  },
+  {
+    "__type__": "cc.ModelLightmapSettings",
+    "texture": null,
+    "uvParam": {
+      "__type__": "cc.Vec4",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 0
     },
-    "startRotationY": {
-      "__id__": 145
+    "_bakeable": false,
+    "_castShadow": false,
+    "_receiveShadow": false,
+    "_recieveShadow": false,
+    "_lightmapSize": 64
+  },
+  {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 127
     },
-    "startRotationZ": {
-      "__id__": 146
+    "propertyPath": [
+      "lightmapSettings"
+    ],
+    "value": {
+      "__id__": 128
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "f7ACrawzhASrxSsW9U/pdO"
+    ]
+  },
+  {
+    "__type__": "cc.ModelLightmapSettings",
+    "texture": null,
+    "uvParam": {
+      "__type__": "cc.Vec4",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 0
     },
-    "startRotation": {
-      "__id__": 146
+    "_bakeable": false,
+    "_castShadow": false,
+    "_receiveShadow": false,
+    "_recieveShadow": false,
+    "_lightmapSize": 64
+  },
+  {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 130
     },
-    "startDelay": {
-      "__id__": 147
+    "propertyPath": [
+      "lightmapSettings"
+    ],
+    "value": {
+      "__id__": 131
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "1dKcsLwQdHNpfVxsSO1ETD"
+    ]
+  },
+  {
+    "__type__": "cc.ModelLightmapSettings",
+    "texture": null,
+    "uvParam": {
+      "__type__": "cc.Vec4",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 0
     },
-    "startLifetime": {
-      "__id__": 148
+    "_bakeable": false,
+    "_castShadow": false,
+    "_receiveShadow": false,
+    "_recieveShadow": false,
+    "_lightmapSize": 64
+  },
+  {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 133
     },
-    "duration": 5,
-    "loop": true,
-    "simulationSpeed": 1,
-    "playOnAwake": false,
-    "gravityModifier": {
-      "__id__": 149
+    "propertyPath": [
+      "lightmapSettings"
+    ],
+    "value": {
+      "__id__": 134
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "6bxqsZ6dBMVoBuLaJSiNI8"
+    ]
+  },
+  {
+    "__type__": "cc.ModelLightmapSettings",
+    "texture": null,
+    "uvParam": {
+      "__type__": "cc.Vec4",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 0
     },
-    "rateOverTime": {
-      "__id__": 150
+    "_bakeable": false,
+    "_castShadow": false,
+    "_receiveShadow": false,
+    "_recieveShadow": false,
+    "_lightmapSize": 64
+  },
+  {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 136
     },
-    "rateOverDistance": {
-      "__id__": 151
-    },
-    "bursts": [],
-    "_colorOverLifetimeModule": {
-      "__id__": 152
-    },
-    "_shapeModule": {
-      "__id__": 154
-    },
-    "_sizeOvertimeModule": {
-      "__id__": 156
-    },
-    "_velocityOvertimeModule": {
-      "__id__": 161
-    },
-    "_forceOvertimeModule": {
-      "__id__": 166
-    },
-    "_limitVelocityOvertimeModule": {
-      "__id__": 170
-    },
-    "_rotationOvertimeModule": {
-      "__id__": 175
-    },
-    "_textureAnimationModule": {
-      "__id__": 179
-    },
-    "_trailModule": {
-      "__id__": 182
-    },
-    "renderer": {
-      "__id__": 187
-    },
-    "enableCulling": false,
-    "_prewarm": false,
-    "_capacity": 100,
-    "_simulationSpace": 1,
-    "_id": "e469zIr+RBdalCxYUyRkrg"
+    "propertyPath": [
+      "startColor"
+    ],
+    "value": {
+      "__id__": 137
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "fbgBe7ZvNGR4uy+r5rhU2j"
+    ]
   },
   {
     "__type__": "cc.GradientRange",
@@ -3293,22 +2921,112 @@
     }
   },
   {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 139
+    },
+    "propertyPath": [
+      "startSizeX"
+    ],
+    "value": {
+      "__id__": 140
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "fbgBe7ZvNGR4uy+r5rhU2j"
+    ]
+  },
+  {
     "__type__": "cc.CurveRange",
     "mode": 0,
     "constant": 0.2,
     "multiplier": 1
   },
   {
-    "__type__": "cc.CurveRange",
-    "mode": 0,
-    "constant": 0,
-    "multiplier": 1
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 142
+    },
+    "propertyPath": [
+      "startSize"
+    ],
+    "value": {
+      "__id__": 140
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "fbgBe7ZvNGR4uy+r5rhU2j"
+    ]
+  },
+  {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 144
+    },
+    "propertyPath": [
+      "startSizeY"
+    ],
+    "value": {
+      "__id__": 145
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "fbgBe7ZvNGR4uy+r5rhU2j"
+    ]
   },
   {
     "__type__": "cc.CurveRange",
     "mode": 0,
     "constant": 0,
     "multiplier": 1
+  },
+  {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 147
+    },
+    "propertyPath": [
+      "startSizeZ"
+    ],
+    "value": {
+      "__id__": 148
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "fbgBe7ZvNGR4uy+r5rhU2j"
+    ]
+  },
+  {
+    "__type__": "cc.CurveRange",
+    "mode": 0,
+    "constant": 0,
+    "multiplier": 1
+  },
+  {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 150
+    },
+    "propertyPath": [
+      "startSpeed"
+    ],
+    "value": {
+      "__id__": 151
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "fbgBe7ZvNGR4uy+r5rhU2j"
+    ]
   },
   {
     "__type__": "cc.CurveRange",
@@ -3317,10 +3035,22 @@
     "multiplier": 1
   },
   {
-    "__type__": "cc.CurveRange",
-    "mode": 0,
-    "constant": 0,
-    "multiplier": 1
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 153
+    },
+    "propertyPath": [
+      "startRotationX"
+    ],
+    "value": {
+      "__id__": 154
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "fbgBe7ZvNGR4uy+r5rhU2j"
+    ]
   },
   {
     "__type__": "cc.CurveRange",
@@ -3329,16 +3059,112 @@
     "multiplier": 1
   },
   {
-    "__type__": "cc.CurveRange",
-    "mode": 0,
-    "constant": 0,
-    "multiplier": 1
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 156
+    },
+    "propertyPath": [
+      "startRotationY"
+    ],
+    "value": {
+      "__id__": 157
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "fbgBe7ZvNGR4uy+r5rhU2j"
+    ]
   },
   {
     "__type__": "cc.CurveRange",
     "mode": 0,
     "constant": 0,
     "multiplier": 1
+  },
+  {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 159
+    },
+    "propertyPath": [
+      "startRotationZ"
+    ],
+    "value": {
+      "__id__": 160
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "fbgBe7ZvNGR4uy+r5rhU2j"
+    ]
+  },
+  {
+    "__type__": "cc.CurveRange",
+    "mode": 0,
+    "constant": 0,
+    "multiplier": 1
+  },
+  {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 162
+    },
+    "propertyPath": [
+      "startRotation"
+    ],
+    "value": {
+      "__id__": 160
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "fbgBe7ZvNGR4uy+r5rhU2j"
+    ]
+  },
+  {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 164
+    },
+    "propertyPath": [
+      "startDelay"
+    ],
+    "value": {
+      "__id__": 165
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "fbgBe7ZvNGR4uy+r5rhU2j"
+    ]
+  },
+  {
+    "__type__": "cc.CurveRange",
+    "mode": 0,
+    "constant": 0,
+    "multiplier": 1
+  },
+  {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 167
+    },
+    "propertyPath": [
+      "startLifetime"
+    ],
+    "value": {
+      "__id__": 168
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "fbgBe7ZvNGR4uy+r5rhU2j"
+    ]
   },
   {
     "__type__": "cc.CurveRange",
@@ -3347,10 +3173,46 @@
     "multiplier": 1
   },
   {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 170
+    },
+    "propertyPath": [
+      "gravityModifier"
+    ],
+    "value": {
+      "__id__": 171
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "fbgBe7ZvNGR4uy+r5rhU2j"
+    ]
+  },
+  {
     "__type__": "cc.CurveRange",
     "mode": 0,
     "constant": 0,
     "multiplier": 1
+  },
+  {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 173
+    },
+    "propertyPath": [
+      "rateOverTime"
+    ],
+    "value": {
+      "__id__": 174
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "fbgBe7ZvNGR4uy+r5rhU2j"
+    ]
   },
   {
     "__type__": "cc.CurveRange",
@@ -3359,16 +3221,52 @@
     "multiplier": 1
   },
   {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 176
+    },
+    "propertyPath": [
+      "rateOverDistance"
+    ],
+    "value": {
+      "__id__": 177
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "fbgBe7ZvNGR4uy+r5rhU2j"
+    ]
+  },
+  {
     "__type__": "cc.CurveRange",
     "mode": 0,
     "constant": 0,
     "multiplier": 1
   },
   {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 179
+    },
+    "propertyPath": [
+      "_colorOverLifetimeModule"
+    ],
+    "value": {
+      "__id__": 180
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "fbgBe7ZvNGR4uy+r5rhU2j"
+    ]
+  },
+  {
     "__type__": "cc.ColorOvertimeModule",
     "_enable": true,
     "color": {
-      "__id__": 153
+      "__id__": 181
     }
   },
   {
@@ -3390,6 +3288,24 @@
     }
   },
   {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 183
+    },
+    "propertyPath": [
+      "_shapeModule"
+    ],
+    "value": {
+      "__id__": 184
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "fbgBe7ZvNGR4uy+r5rhU2j"
+    ]
+  },
+  {
     "__type__": "cc.ShapeModule",
     "_enable": true,
     "_shapeType": 0,
@@ -3404,7 +3320,7 @@
     "arcMode": 0,
     "arcSpread": 0,
     "arcSpeed": {
-      "__id__": 155
+      "__id__": 185
     },
     "length": 5,
     "boxThickness": {
@@ -3441,20 +3357,38 @@
     "multiplier": 1
   },
   {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 187
+    },
+    "propertyPath": [
+      "_sizeOvertimeModule"
+    ],
+    "value": {
+      "__id__": 188
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "fbgBe7ZvNGR4uy+r5rhU2j"
+    ]
+  },
+  {
     "__type__": "cc.SizeOvertimeModule",
     "_enable": false,
     "separateAxes": false,
     "size": {
-      "__id__": 157
+      "__id__": 189
     },
     "x": {
-      "__id__": 158
+      "__id__": 190
     },
     "y": {
-      "__id__": 159
+      "__id__": 191
     },
     "z": {
-      "__id__": 160
+      "__id__": 192
     }
   },
   {
@@ -3482,19 +3416,37 @@
     "multiplier": 1
   },
   {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 194
+    },
+    "propertyPath": [
+      "_velocityOvertimeModule"
+    ],
+    "value": {
+      "__id__": 195
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "fbgBe7ZvNGR4uy+r5rhU2j"
+    ]
+  },
+  {
     "__type__": "cc.VelocityOvertimeModule",
     "_enable": false,
     "x": {
-      "__id__": 162
+      "__id__": 196
     },
     "y": {
-      "__id__": 163
+      "__id__": 197
     },
     "z": {
-      "__id__": 164
+      "__id__": 198
     },
     "speedModifier": {
-      "__id__": 165
+      "__id__": 199
     },
     "space": 1
   },
@@ -3523,16 +3475,34 @@
     "multiplier": 1
   },
   {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 201
+    },
+    "propertyPath": [
+      "_forceOvertimeModule"
+    ],
+    "value": {
+      "__id__": 202
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "fbgBe7ZvNGR4uy+r5rhU2j"
+    ]
+  },
+  {
     "__type__": "cc.ForceOvertimeModule",
     "_enable": false,
     "x": {
-      "__id__": 167
+      "__id__": 203
     },
     "y": {
-      "__id__": 168
+      "__id__": 204
     },
     "z": {
-      "__id__": 169
+      "__id__": 205
     },
     "space": 1
   },
@@ -3555,19 +3525,37 @@
     "multiplier": 1
   },
   {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 207
+    },
+    "propertyPath": [
+      "_limitVelocityOvertimeModule"
+    ],
+    "value": {
+      "__id__": 208
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "fbgBe7ZvNGR4uy+r5rhU2j"
+    ]
+  },
+  {
     "__type__": "cc.LimitVelocityOvertimeModule",
     "_enable": false,
     "limitX": {
-      "__id__": 171
+      "__id__": 209
     },
     "limitY": {
-      "__id__": 172
+      "__id__": 210
     },
     "limitZ": {
-      "__id__": 173
+      "__id__": 211
     },
     "limit": {
-      "__id__": 174
+      "__id__": 212
     },
     "dampen": 3,
     "separateAxes": false,
@@ -3598,17 +3586,35 @@
     "multiplier": 1
   },
   {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 214
+    },
+    "propertyPath": [
+      "_rotationOvertimeModule"
+    ],
+    "value": {
+      "__id__": 215
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "fbgBe7ZvNGR4uy+r5rhU2j"
+    ]
+  },
+  {
     "__type__": "cc.RotationOvertimeModule",
     "_enable": false,
     "_separateAxes": false,
     "x": {
-      "__id__": 176
+      "__id__": 216
     },
     "y": {
-      "__id__": 177
+      "__id__": 217
     },
     "z": {
-      "__id__": 178
+      "__id__": 218
     }
   },
   {
@@ -3630,6 +3636,24 @@
     "multiplier": 1
   },
   {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 220
+    },
+    "propertyPath": [
+      "_textureAnimationModule"
+    ],
+    "value": {
+      "__id__": 221
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "fbgBe7ZvNGR4uy+r5rhU2j"
+    ]
+  },
+  {
     "__type__": "cc.TextureAnimationModule",
     "_enable": false,
     "_numTilesX": 0,
@@ -3639,10 +3663,10 @@
     "_mode": 0,
     "animation": 0,
     "frameOverTime": {
-      "__id__": 180
+      "__id__": 222
     },
     "startFrame": {
-      "__id__": 181
+      "__id__": 223
     },
     "cycleCount": 0,
     "_flipU": 0,
@@ -3664,30 +3688,46 @@
     "multiplier": 1
   },
   {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 225
+    },
+    "propertyPath": [
+      "_trailModule"
+    ],
+    "value": {
+      "__id__": 226
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "fbgBe7ZvNGR4uy+r5rhU2j"
+    ]
+  },
+  {
     "__type__": "cc.TrailModule",
     "_enable": false,
     "mode": 0,
     "lifeTime": {
-      "__id__": 183
+      "__id__": 227
     },
     "_minParticleDistance": 0.1,
     "existWithParticles": true,
     "textureMode": 0,
     "widthFromParticle": true,
     "widthRatio": {
-      "__id__": 184
+      "__id__": 228
     },
     "colorFromParticle": false,
     "colorOverTrail": {
-      "__id__": 185
+      "__id__": 229
     },
     "colorOvertime": {
-      "__id__": 186
+      "__id__": 230
     },
     "_space": 0,
-    "_particleSystem": {
-      "__id__": 138
-    }
+    "_particleSystem": null
   },
   {
     "__type__": "cc.CurveRange",
@@ -3724,112 +3764,66 @@
     }
   },
   {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 232
+    },
+    "propertyPath": [
+      "renderer"
+    ],
+    "value": {
+      "__id__": 233
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "fbgBe7ZvNGR4uy+r5rhU2j"
+    ]
+  },
+  {
     "__type__": "cc.ParticleSystemRenderer",
     "_renderMode": 0,
     "_velocityScale": 1,
     "_lengthScale": 1,
     "_mesh": null,
     "_mainTexture": {
-      "__uuid__": "fe262dd1-1451-449b-9fe9-61c6a1f6d1a6@6c48a"
+      "__uuid__": "fe262dd1-1451-449b-9fe9-61c6a1f6d1a6@6c48a",
+      "__expectedType__": "cc.Texture2D"
     },
     "_useGPU": false
   },
   {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 106
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 235
     },
-    "asset": {
-      "__uuid__": "7470a7d3-6662-4190-be25-ffeffe754a5c"
-    },
-    "fileId": "e6yRw4zRBDc6UCy+lGjdNA"
+    "propertyPath": [
+      "_group"
+    ],
+    "value": 2
   },
   {
-    "__type__": "4b61aYXI2JBZ6e1QOqrIjA9",
-    "_name": "car101<Car>",
-    "_objFlags": 0,
-    "node": {
-      "__id__": 106
-    },
-    "_enabled": true,
-    "__prefab": {
-      "__id__": 335
-    },
-    "maxSpeed": 0.2,
-    "minSpeed": 0.02,
-    "_id": "70Zm35y1hGWbzRQbG0DJJe"
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "ebwKJd69ZPzLBWUcinaKmy"
+    ]
   },
   {
-    "__type__": "cc.BoxCollider",
-    "_name": "car101<BoxCollider>",
-    "_objFlags": 0,
-    "node": {
-      "__id__": 106
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 237
     },
-    "_enabled": true,
-    "__prefab": {
-      "__id__": 336
-    },
-    "_material": null,
-    "_isTrigger": false,
-    "_center": {
-      "__type__": "cc.Vec3",
-      "x": 0,
-      "y": 0.3,
-      "z": 0
-    },
-    "_size": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 0.5,
-      "z": 1.2
-    },
-    "_id": "c4wEVkFiVB2b0fP5gnVhqJ"
+    "propertyPath": [
+      "_type"
+    ],
+    "value": 1
   },
   {
-    "__type__": "cc.RigidBody",
-    "_name": "car101<RigidBody>",
-    "_objFlags": 0,
-    "node": {
-      "__id__": 106
-    },
-    "_enabled": true,
-    "__prefab": {
-      "__id__": 337
-    },
-    "_group": 2,
-    "_type": 1,
-    "_mass": 10,
-    "_allowSleep": true,
-    "_linearDamping": 0,
-    "_angularDamping": 0,
-    "_useGravity": false,
-    "_linearFactor": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 1,
-      "z": 1
-    },
-    "_angularFactor": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 1,
-      "z": 1
-    },
-    "_id": "e1bmlyGT5No5PqvTsK+zNO"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 106
-    },
-    "asset": {
-      "__uuid__": "7470a7d3-6662-4190-be25-ffeffe754a5c"
-    },
-    "fileId": "8di29+BXJCNLrma/FTq1Lc",
-    "instance": {
-      "__id__": 342
-    }
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "ebwKJd69ZPzLBWUcinaKmy"
+    ]
   },
   {
     "__type__": "cc.Node",
@@ -3842,7 +3836,7 @@
     "_active": true,
     "_components": [
       {
-        "__id__": 194
+        "__id__": 239
       }
     ],
     "_prefab": null,
@@ -3879,7 +3873,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 193
+      "__id__": 238
     },
     "_enabled": true,
     "__prefab": null,
@@ -3926,7 +3920,7 @@
     "_active": true,
     "_components": [
       {
-        "__id__": 196
+        "__id__": 241
       }
     ],
     "_prefab": null,
@@ -3963,7 +3957,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 195
+      "__id__": 240
     },
     "_enabled": true,
     "__prefab": null,
@@ -3988,7 +3982,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 5
+      "__id__": 8
     },
     "_enabled": true,
     "__prefab": null,
@@ -4021,16 +4015,16 @@
     },
     "_children": [
       {
-        "__id__": 199
+        "__id__": 244
       },
       {
-        "__id__": 258
+        "__id__": 260
       }
     ],
     "_active": true,
     "_components": [
       {
-        "__id__": 317
+        "__id__": 276
       }
     ],
     "_prefab": null,
@@ -4066,137 +4060,109 @@
     "__type__": "cc.Node",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 198
+      "__id__": 243
     },
     "_prefab": {
-      "__id__": 257
+      "__id__": 245
     },
     "_id": "3ap6ogzlNE/J7ku0lDk0Hz"
   },
   {
-    "__type__": "cc.Node",
-    "_name": "RootNode",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 199
+    "__type__": "cc.PrefabInfo",
+    "root": {
+      "__id__": 244
     },
-    "_children": [
+    "asset": {
+      "__uuid__": "5f1d311e-2789-42cf-80ec-48844298373e",
+      "__expectedType__": "cc.Prefab"
+    },
+    "fileId": "88g4ZyJA1IaaaiBa9sOJV/",
+    "instance": {
+      "__id__": 246
+    }
+  },
+  {
+    "__type__": "cc.PrefabInstance",
+    "fileId": "f0T96nPutECbrrXd8snisz",
+    "prefabRootNode": null,
+    "mountedChildren": [],
+    "mountedComponents": [],
+    "propertyOverrides": [
       {
-        "__id__": 201
+        "__id__": 247
       },
       {
-        "__id__": 205
+        "__id__": 249
+      },
+      {
+        "__id__": 251
+      },
+      {
+        "__id__": 254
+      },
+      {
+        "__id__": 256
+      },
+      {
+        "__id__": 258
       }
     ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 255
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0,
-      "y": 0,
-      "z": 0
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": 0,
-      "y": 0,
-      "z": 0,
-      "w": 1
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 1,
-      "z": 1
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": 0,
-      "y": 0,
-      "z": 0
-    },
-    "_id": "c7anYtiw5AFI9JswM/fc8T"
+    "removedComponents": []
   },
   {
-    "__type__": "cc.Node",
-    "_name": "girl02",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 200
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 248
     },
-    "_children": [],
-    "_active": true,
-    "_components": [
-      {
-        "__id__": 202
-      }
+    "propertyPath": [
+      "position"
     ],
-    "_prefab": {
-      "__id__": 204
-    },
-    "_lpos": {
+    "value": {
       "__type__": "cc.Vec3",
       "x": 0,
       "y": 0,
       "z": 0
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": 0.7071068407911882,
-      "y": 0.7071067215818972,
-      "z": 5.7601156830878716e-8,
-      "w": 5.760116748901989e-8
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 40.8631820678711,
-      "y": 40.8631820678711,
-      "z": 40.8631820678711
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": 0,
-      "y": 179.99999066533204,
-      "z": 90
-    },
-    "_id": "61UBg6/rBG3Jqt/UzK1dEi"
+    }
   },
   {
-    "__type__": "cc.SkinnedMeshRenderer",
-    "_name": "",
-    "_objFlags": 0,
-    "node": {
-      "__id__": 201
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "88g4ZyJA1IaaaiBa9sOJV/"
+    ]
+  },
+  {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 250
     },
-    "_enabled": true,
-    "__prefab": {
-      "__id__": 338
-    },
-    "_materials": [
-      {
-        "__uuid__": "14ea35e0-8945-43a0-82b1-9c6fc27a7863@fe5ee"
-      }
+    "propertyPath": [
+      "_active"
     ],
-    "_visFlags": 0,
-    "lightmapSettings": {
-      "__id__": 203
+    "value": false
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "88g4ZyJA1IaaaiBa9sOJV/"
+    ]
+  },
+  {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 252
     },
-    "_mesh": {
-      "__uuid__": "14ea35e0-8945-43a0-82b1-9c6fc27a7863@274e2"
-    },
-    "_shadowCastingMode": 0,
-    "_shadowReceivingMode": 1,
-    "_enableMorph": true,
-    "_skeleton": {
-      "__uuid__": "14ea35e0-8945-43a0-82b1-9c6fc27a7863@438fe"
-    },
-    "_skinningRoot": null,
-    "_id": "9b34N5QbNEVqZX5iEIFCXr"
+    "propertyPath": [
+      "lightmapSettings"
+    ],
+    "value": {
+      "__id__": 253
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "86e9p0OV1BQqlFFm6wz/P5"
+    ]
   },
   {
     "__type__": "cc.ModelLightmapSettings",
@@ -4215,3013 +4181,241 @@
     "_lightmapSize": 64
   },
   {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 199
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 255
     },
-    "asset": {
-      "__uuid__": "5f1d311e-2789-42cf-80ec-48844298373e"
-    },
-    "fileId": "47x7av+t1LDZMOAkQSzw0V"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip002",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 200
-    },
-    "_children": [
-      {
-        "__id__": 206
-      },
-      {
-        "__id__": 208
-      }
+    "propertyPath": [
+      "_shadowReceivingMode"
     ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 254
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.000437296781456098,
-      "y": 0.162740305066109,
-      "z": -9.34606725344622e-10
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": -0.5000003576277411,
-      "y": -0.4999996423720031,
-      "z": -0.4999996423720031,
-      "w": 0.5000003576277411
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 0.999999940395355,
-      "y": 0.999999940395355,
-      "z": 1
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": -90,
-      "y": -89.99991803772988,
-      "z": 0
-    },
-    "_id": "366GoCyihM3bCSfsjDGD8E"
+    "value": 1
   },
   {
-    "__type__": "cc.Node",
-    "_name": "Bip002 Footsteps",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 205
-    },
-    "_children": [],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 207
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": -1.32348895050256e-25,
-      "y": 0,
-      "z": -0.15406209230423
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": -6.921397640638601e-34,
-      "y": 6.921406824188368e-34,
-      "z": 0.7071063043492202,
-      "w": 0.7071072580235535
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 1,
-      "z": 1
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": 0,
-      "y": -1.1216597443755499e-31,
-      "z": 90
-    },
-    "_id": "72xrAWZ29MeYVUeR765bhI"
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "86e9p0OV1BQqlFFm6wz/P5"
+    ]
   },
   {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 199
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 257
     },
-    "asset": {
-      "__uuid__": "5f1d311e-2789-42cf-80ec-48844298373e"
-    },
-    "fileId": "02/xXArl5APIN2yREMHmgQ"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip002 Pelvis",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 205
-    },
-    "_children": [
-      {
-        "__id__": 209
-      }
+    "propertyPath": [
+      "_enableMorph"
     ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 253
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0,
-      "y": 0,
-      "z": 0
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": 0.4639031022988035,
-      "y": 0.5336602364722678,
-      "z": 0.5086500081534693,
-      "w": -0.49119836409681256
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 1,
-      "z": 0.999999940395355
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": -87.01131714275752,
-      "y": -94.99317424741686,
-      "z": -0.26143153717816514
-    },
-    "_id": "13t2WLUrBC/p8+OLqz9UVB"
+    "value": true
   },
   {
-    "__type__": "cc.Node",
-    "_name": "Bip002 Spine",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 208
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "86e9p0OV1BQqlFFm6wz/P5"
+    ]
+  },
+  {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 259
     },
-    "_children": [
-      {
-        "__id__": 210
-      },
-      {
-        "__id__": 220
-      },
-      {
-        "__id__": 230
-      }
+    "propertyPath": [
+      "_useBakedAnimation"
     ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 252
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.0204302202910185,
-      "y": 0.00175504083745182,
-      "z": 0.00000172115858276811
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": -0.023899123587258018,
-      "y": -0.05340169485167406,
-      "z": 0.045309160880387084,
-      "w": 0.9972583270241693
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 0.999999940395355,
-      "y": 0.999999940395355,
-      "z": 1
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": -2.4652890086503874,
-      "y": -6.015545672330229,
-      "z": 5.331752141692003
-    },
-    "_id": "5b49CMIztOH55lFruTmexO"
+    "value": true
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "d9wSQXQRRBXYhff8jd0S72"
+    ]
   },
   {
     "__type__": "cc.Node",
-    "_name": "Bip002 L Thigh",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 209
-    },
-    "_children": [
-      {
-        "__id__": 211
-      }
-    ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 219
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": -0.0188402365893126,
-      "y": -0.000732986663933843,
-      "z": 0.0169235672801733
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": -0.2183414644006629,
-      "y": 0.9729575275764636,
-      "z": 0.0036262333433554226,
-      "w": -0.07528283262078105
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 1,
-      "z": 1.00000023841858
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": 1.6347974606109208,
-      "y": -170.78597732356607,
-      "z": -25.177246440163934
-    },
-    "_id": "e3sgNT/LNDIqvIOsnkq3kT"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip002 L Calf",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 210
-    },
-    "_children": [
-      {
-        "__id__": 212
-      }
-    ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 218
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.0700375437736511,
-      "y": 0,
-      "z": 4.44089199923895e-18
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": 1.7321630160985365e-18,
-      "y": -1.7372800586894758e-18,
-      "z": -0.0014749332112373795,
-      "w": 0.9999989122854195
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1.00000011920929,
-      "y": 0.999999940395355,
-      "z": 1
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": 1.9819828072384956e-16,
-      "y": -1.9878551738554966e-16,
-      "z": -0.1690149574151743
-    },
-    "_id": "d4zTSc1lZLbY1iZhBBJ6Rd"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip002 L Foot",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 211
-    },
-    "_children": [
-      {
-        "__id__": 213
-      }
-    ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 217
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.0700375437736511,
-      "y": 8.88178399847791e-18,
-      "z": 0
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": -0.0035255051400618583,
-      "y": -0.02528195688425971,
-      "z": 0.047374614454261756,
-      "w": 0.9985509698432625
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 0.999999940395355,
-      "y": 0.999999940395355,
-      "z": 0.999999821186066
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": -0.26736362248194634,
-      "y": -2.8879828826471585,
-      "z": 5.439244536940238
-    },
-    "_id": "76g1Dh+9RMS5INFan19+DC"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip002 L Toe0",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 212
-    },
-    "_children": [
-      {
-        "__id__": 214
-      }
-    ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 216
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.0223976150155067,
-      "y": 0.0288247391581535,
-      "z": 0
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": -1.5454231936639717e-8,
-      "y": -1.5454393585114783e-8,
-      "z": 0.7071067811865472,
-      "w": 0.7071067811865472
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 1,
-      "z": 0.999999940395355
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": 0,
-      "y": -0.000002504465489921935,
-      "z": 90
-    },
-    "_id": "9eSA0dnLNCAInYki9XihZ4"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip002 L Toe0Nub",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 213
-    },
-    "_children": [],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 215
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.00292142387479544,
-      "y": 5.9604643443123e-10,
-      "z": -4.44089199923895e-18
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": -7.8159700933611e-14,
-      "y": -1.4210854715202e-14,
-      "z": 1,
-      "w": -6.12323426292584e-17
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": -1,
-      "y": -1,
-      "z": -0.999999940395355
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": 179.99999999999838,
-      "y": 179.99999999999105,
-      "z": -7.016709604583723e-15
-    },
-    "_id": "02tjJStmdFJqvHRErLfcJw"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 199
-    },
-    "asset": {
-      "__uuid__": "5f1d311e-2789-42cf-80ec-48844298373e"
-    },
-    "fileId": "24+KNGNk5GkJvIPKhuHrZr"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 199
-    },
-    "asset": {
-      "__uuid__": "5f1d311e-2789-42cf-80ec-48844298373e"
-    },
-    "fileId": "cb+V5csKhHRpZ3+SdCj8Vo"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 199
-    },
-    "asset": {
-      "__uuid__": "5f1d311e-2789-42cf-80ec-48844298373e"
-    },
-    "fileId": "69azT8/Q5C348aVcraDL5y"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 199
-    },
-    "asset": {
-      "__uuid__": "5f1d311e-2789-42cf-80ec-48844298373e"
-    },
-    "fileId": "e19Tj2FaNMQKHmKBW2vn4o"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 199
-    },
-    "asset": {
-      "__uuid__": "5f1d311e-2789-42cf-80ec-48844298373e"
-    },
-    "fileId": "52JoS0RJ1LZK9VHpVrqDew"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip002 R Thigh",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 209
-    },
-    "_children": [
-      {
-        "__id__": 221
-      }
-    ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 229
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": -0.0219459142535925,
-      "y": 0.000829772558063269,
-      "z": -0.0126367602497339
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": 0.1947318923662233,
-      "y": 0.9804793657240825,
-      "z": -0.020850494633637986,
-      "w": -0.017463114221213563
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 1,
-      "z": 1.00000011920929
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": 2.114267257603782,
-      "y": -178.37973725527408,
-      "z": 22.494170658225208
-    },
-    "_id": "d8qB8AitFB2JAmghQGlqeI"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip002 R Calf",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 220
-    },
-    "_children": [
-      {
-        "__id__": 222
-      }
-    ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 228
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.0700375512242317,
-      "y": 8.88178399847791e-18,
-      "z": -4.44089199923895e-18
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": 3.537500676179295e-18,
-      "y": 5.248484650688316e-19,
-      "z": -0.09753086944804883,
-      "w": 0.9952325002253031
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 0.999999940395355,
-      "y": 1.00000011920929,
-      "z": 1
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": 4.172387211552533e-16,
-      "y": 1.0131990171498933e-16,
-      "z": -11.194009189068657
-    },
-    "_id": "ae5kw22wFKM6VSRAF5MNyy"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip002 R Foot",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 221
-    },
-    "_children": [
-      {
-        "__id__": 223
-      }
-    ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 227
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.0700375437736511,
-      "y": -4.76837147544984e-9,
-      "z": 2.38418573772492e-9
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": -0.009866906217861028,
-      "y": 0.034147612362473684,
-      "z": 0.02328710231543379,
-      "w": 0.9990967398592494
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1.00000011920929,
-      "y": 1,
-      "z": 0.999999940395355
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": -1.222144295771838,
-      "y": 3.9430803379790462,
-      "z": 2.628407321402902
-    },
-    "_id": "61rDNVuLBH65v7n+6V+IMd"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip002 R Toe0",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 222
-    },
-    "_children": [
-      {
-        "__id__": 224
-      }
-    ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 226
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.0223976131528616,
-      "y": 0.0288247391581535,
-      "z": 0
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": -1.545433318898125e-8,
-      "y": -1.5454292332773253e-8,
-      "z": 0.7071067811865472,
-      "w": 0.7071067811865472
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 1,
-      "z": 0.999999940395355
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": 0,
-      "y": -0.000002504481898566259,
-      "z": 90
-    },
-    "_id": "91DkGM3stDCopMXzERCoiE"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip002 R Toe0Nub",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 223
-    },
-    "_children": [],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 225
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.00292142853140831,
-      "y": -1.19209286886246e-9,
-      "z": 0
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": -2.64697796016969e-23,
-      "y": -2.11758236813575e-22,
-      "z": 1.38777878078145e-17,
-      "w": 1
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 1,
-      "z": 0.999999940395355
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": -3.0332133116374183e-21,
-      "y": -2.426570649309933e-20,
-      "z": 1.5902773407317633e-15
-    },
-    "_id": "961ERCdd5Cx63VHZj+Mq1x"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 199
-    },
-    "asset": {
-      "__uuid__": "5f1d311e-2789-42cf-80ec-48844298373e"
-    },
-    "fileId": "a15HFC1yFKkJneZpAP93tw"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 199
-    },
-    "asset": {
-      "__uuid__": "5f1d311e-2789-42cf-80ec-48844298373e"
-    },
-    "fileId": "89Z7thzQRB7KxWo/NCXYjY"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 199
-    },
-    "asset": {
-      "__uuid__": "5f1d311e-2789-42cf-80ec-48844298373e"
-    },
-    "fileId": "15LtTzlPRH3oygMP2QHM8v"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 199
-    },
-    "asset": {
-      "__uuid__": "5f1d311e-2789-42cf-80ec-48844298373e"
-    },
-    "fileId": "ad3BdLYDJAS7vmhpN/1mfp"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 199
-    },
-    "asset": {
-      "__uuid__": "5f1d311e-2789-42cf-80ec-48844298373e"
-    },
-    "fileId": "1ehHqUmuRHrZ08F++YY3oX"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip002 Neck",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 209
-    },
-    "_children": [
-      {
-        "__id__": 231
-      },
-      {
-        "__id__": 239
-      },
-      {
-        "__id__": 247
-      }
-    ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 251
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.04056241735816,
-      "y": -0.0000115188577183289,
-      "z": -1.19209286886246e-9
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": -1.6304913422550135e-10,
-      "y": -1.9793392002093858e-7,
-      "z": 0.06975654703976333,
-      "w": 0.9975640451344716
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 1,
-      "z": 1
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": 0.0000015789144395922164,
-      "y": -0.000022847351215093253,
-      "z": 8.000008419570952
-    },
-    "_id": "2bUyBkp9FJS6vPHri5UQz0"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip002 L Clavicle",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 230
-    },
-    "_children": [
-      {
-        "__id__": 232
-      }
-    ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 238
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0,
-      "y": 0.0000116229057312012,
-      "z": 0.00303001631982625
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": 0.7053011001413734,
-      "y": -0.05050288098994343,
-      "z": 0.7053009809320844,
-      "w": 0.050500925212552915
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 0.999999940395355,
-      "z": 1
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": 171.8088424933077,
-      "y": -90.00000168358433,
-      "z": -0.0001587588270774338
-    },
-    "_id": "9aTr/Bp4ZK77Bg9YODVfJL"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip002 L UpperArm",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 231
-    },
-    "_children": [
-      {
-        "__id__": 233
-      }
-    ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 237
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.00960996001958847,
-      "y": 7.2759574515531e-14,
-      "z": 3.55271359939116e-17
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": -0.1424355394984832,
-      "y": 0.353935161511024,
-      "z": -0.03679229042397618,
-      "w": 0.9236278178461816
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1.00000011920929,
-      "y": 1.00000011920929,
-      "z": 1.00000011920929
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": -13.917333933748846,
-      "y": 40.744917188886646,
-      "z": -9.717512759317453
-    },
-    "_id": "b6eXil6RZOfKtgwNIk53Rv"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip002 L Forearm",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 232
-    },
-    "_children": [
-      {
-        "__id__": 234
-      }
-    ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 236
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.0477933213114738,
-      "y": 0,
-      "z": 0
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": -1.6442472542069355e-17,
-      "y": -5.302011558705977e-17,
-      "z": -0.29620125285405213,
-      "w": 0.9551255508087352
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 0.99999988079071,
-      "z": 0.999999940395355
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": -4.365197811001507e-15,
-      "y": -7.714833677314763e-15,
-      "z": -34.45916746430055
-    },
-    "_id": "99VDFLQFJAJKiMtjxWHRV2"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip002 L Hand",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 233
-    },
-    "_children": [],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 235
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.0584285110235214,
-      "y": 9.53674295089968e-9,
-      "z": 9.53674295089968e-9
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": -0.706825182602914,
-      "y": -1.054090660319988e-8,
-      "z": -1.0532516870015218e-8,
-      "w": 0.7073882676708435
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 0.999999940395355,
-      "y": 0.999999940395355,
-      "z": 0.99999988079071
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": -89.95437407813075,
-      "y": -0.000001707547364442261,
-      "z": -7.199638481473593e-14
-    },
-    "_id": "16Src3TEZHtbNMOL/IofoM"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 199
-    },
-    "asset": {
-      "__uuid__": "5f1d311e-2789-42cf-80ec-48844298373e"
-    },
-    "fileId": "56fjTQFwZFBIRmCXdFrKOI"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 199
-    },
-    "asset": {
-      "__uuid__": "5f1d311e-2789-42cf-80ec-48844298373e"
-    },
-    "fileId": "baib5pwIxALKQg2ON9WPbY"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 199
-    },
-    "asset": {
-      "__uuid__": "5f1d311e-2789-42cf-80ec-48844298373e"
-    },
-    "fileId": "fcXePJ1PtBMKt0LsNa/nlD"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 199
-    },
-    "asset": {
-      "__uuid__": "5f1d311e-2789-42cf-80ec-48844298373e"
-    },
-    "fileId": "893AmkMo5PrJWJGh/nZuXM"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip002 R Clavicle",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 230
-    },
-    "_children": [
-      {
-        "__id__": 240
-      }
-    ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 246
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": -1.90734859017994e-8,
-      "y": 0.0000116443634397001,
-      "z": -0.00303001631982625
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": -0.7053756700329976,
-      "y": 0.04944677268909895,
-      "z": 0.7053757892422864,
-      "w": 0.0494487284665019
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 0.999999940395355,
-      "z": 1
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": -171.9801034953782,
-      "y": 89.9999985536879,
-      "z": 0.00015876116694949215
-    },
-    "_id": "dbQ1p5vgJEPbdwmX23IH4m"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip002 R UpperArm",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 239
-    },
-    "_children": [
-      {
-        "__id__": 241
-      }
-    ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 245
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.00960996095091105,
-      "y": -7.2759574515531e-14,
-      "z": -1.90734859017994e-8
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": -0.38115223624558575,
-      "y": -0.3888133701260311,
-      "z": 0.17197267432483307,
-      "w": 0.8209583030226274
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1.00000011920929,
-      "y": 1,
-      "z": 1.00000011920929
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": -37.11535815387628,
-      "y": -38.46802369915586,
-      "z": 35.36330181212289
-    },
-    "_id": "8fqzMOvLJCcpaUWSbp7Utv"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip002 R Forearm",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 240
-    },
-    "_children": [
-      {
-        "__id__": 242
-      }
-    ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 244
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.0477933250367641,
-      "y": 0,
-      "z": 0
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": -8.819167358589412e-18,
-      "y": -4.068856483105306e-17,
-      "z": -0.2118293221255404,
-      "w": 0.9773066756590962
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 1.00000035762787,
-      "z": 1
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": -2.1700872704076287e-15,
-      "y": -5.2411943165299716e-15,
-      "z": -24.45915354200795
-    },
-    "_id": "4b62evRrxD25xS5emk3Rkq"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip002 R Hand",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 241
-    },
-    "_children": [],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
       "__id__": 243
     },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.0584285520017147,
-      "y": 9.53674295089968e-9,
-      "z": 0
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": 0.7068252124052272,
-      "y": 4.905366429592439e-17,
-      "z": 2.945876761941854e-17,
-      "w": 0.707388237892252
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 0.999999940395355,
-      "z": 1
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": 89.95437890588059,
-      "y": 1.5902770726844353e-15,
-      "z": 6.361109497084122e-15
-    },
-    "_id": "3cNMyayYJMgYzuuBCAtugN"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 199
-    },
-    "asset": {
-      "__uuid__": "5f1d311e-2789-42cf-80ec-48844298373e"
-    },
-    "fileId": "62OddpPfZPu4gPNvIXi5HO"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 199
-    },
-    "asset": {
-      "__uuid__": "5f1d311e-2789-42cf-80ec-48844298373e"
-    },
-    "fileId": "70SxUdrMhNEK8/09iW285G"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 199
-    },
-    "asset": {
-      "__uuid__": "5f1d311e-2789-42cf-80ec-48844298373e"
-    },
-    "fileId": "2exPQ/hSVOra89m7BLnQQS"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 199
-    },
-    "asset": {
-      "__uuid__": "5f1d311e-2789-42cf-80ec-48844298373e"
-    },
-    "fileId": "7e7ROTjilEIbAcBb2+Em2L"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip002 Head",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 230
-    },
-    "_children": [
-      {
-        "__id__": 248
-      }
-    ],
-    "_active": true,
-    "_components": [],
     "_prefab": {
-      "__id__": 250
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.0146071240305901,
-      "y": -4.44089199923895e-18,
-      "z": -2.38418573772492e-9
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": -0.12414241430917577,
-      "y": 0.06527382055870816,
-      "z": -0.02812005545214077,
-      "w": 0.9897157429285072
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1.00000011920929,
-      "y": 0.999999940395355,
-      "z": 1.00000011920929
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": -14.045240106899755,
-      "y": 7.038724321573004,
-      "z": -4.121298815756171
-    },
-    "_id": "c2L9tm7plKaJsxSzZEpwtD"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip002 HeadNub",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 247
-    },
-    "_children": [],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 249
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.140986859798431,
-      "y": 1.19209286886246e-9,
-      "z": -1.11022299980974e-18
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": 8.09628897258108e-9,
-      "y": 1.28267174659413e-10,
-      "z": 1.28392997718817e-17,
-      "w": 1
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 0.999999940395355,
-      "z": 1
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": 9.277663756944109e-7,
-      "y": 1.4698335516103482e-8,
-      "z": 1.5902773494185298e-15
-    },
-    "_id": "15NHFirnZD4L8Pay/9qmaw"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 199
-    },
-    "asset": {
-      "__uuid__": "5f1d311e-2789-42cf-80ec-48844298373e"
-    },
-    "fileId": "6cwlqAa3xM3YDzo1aZGl4Z"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 199
-    },
-    "asset": {
-      "__uuid__": "5f1d311e-2789-42cf-80ec-48844298373e"
-    },
-    "fileId": "514VcYeipEAZYK9Bibi8/z"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 199
-    },
-    "asset": {
-      "__uuid__": "5f1d311e-2789-42cf-80ec-48844298373e"
-    },
-    "fileId": "a32+Vo9E1F2IB1L0fjav1P"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 199
-    },
-    "asset": {
-      "__uuid__": "5f1d311e-2789-42cf-80ec-48844298373e"
-    },
-    "fileId": "b53xK1TApDi7VU8mGclAw/"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 199
-    },
-    "asset": {
-      "__uuid__": "5f1d311e-2789-42cf-80ec-48844298373e"
-    },
-    "fileId": "1doBrbEmRPJaerE2NufZ3+"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 199
-    },
-    "asset": {
-      "__uuid__": "5f1d311e-2789-42cf-80ec-48844298373e"
-    },
-    "fileId": "b6LfgpHLhKLazhJiYT0C0m"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 199
-    },
-    "asset": {
-      "__uuid__": "5f1d311e-2789-42cf-80ec-48844298373e"
-    },
-    "fileId": "76TNCKdTBJSZLONl7GhU9R"
-  },
-  {
-    "__type__": "cc.SkeletalAnimation",
-    "_name": "",
-    "_objFlags": 0,
-    "node": {
-      "__id__": 199
-    },
-    "_enabled": true,
-    "__prefab": {
-      "__id__": 339
-    },
-    "playOnLoad": false,
-    "_clips": [
-      {
-        "__uuid__": "3428b334-9c03-49d6-8d06-2b7873e4cdc4@7f3dc"
-      }
-    ],
-    "_defaultClip": null,
-    "_useBakedAnimation": true,
-    "_sockets": [],
-    "_id": "93+F1YL55GFqdLF2X7/kgc"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 199
-    },
-    "asset": {
-      "__uuid__": "5f1d311e-2789-42cf-80ec-48844298373e"
-    },
-    "fileId": "88g4ZyJA1IaaaiBa9sOJV/",
-    "instance": {
-      "__id__": 343
-    }
-  },
-  {
-    "__type__": "cc.Node",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 198
-    },
-    "_prefab": {
-      "__id__": 316
+      "__id__": 261
     },
     "_id": "6dFv5Pz89ImJLl1tmo17PB"
   },
   {
-    "__type__": "cc.Node",
-    "_name": "RootNode",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 258
-    },
-    "_children": [
-      {
-        "__id__": 260
-      },
-      {
-        "__id__": 264
-      }
-    ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 314
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0,
-      "y": 0,
-      "z": 0
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": 0,
-      "y": 0,
-      "z": 0,
-      "w": 1
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 1,
-      "z": 1
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": 0,
-      "y": 0,
-      "z": 0
-    },
-    "_id": "2035/ZjaNOarsoKKaJRnCn"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "muchangguanliyuan_01",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 259
-    },
-    "_children": [],
-    "_active": true,
-    "_components": [
-      {
-        "__id__": 261
-      }
-    ],
-    "_prefab": {
-      "__id__": 263
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0,
-      "y": 0,
-      "z": 0
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": 0.7071068407911905,
-      "y": 0.7071067215818994,
-      "z": 1.5454308319985065e-8,
-      "w": 1.5454311872698724e-8
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 40.9290542602539,
-      "y": 40.9290542602539,
-      "z": 40.9290542602539
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": 0,
-      "y": 179.99999749552177,
-      "z": 90
-    },
-    "_id": "caH7YbsL5JorINPS0V3+D9"
-  },
-  {
-    "__type__": "cc.SkinnedMeshRenderer",
-    "_name": "",
-    "_objFlags": 0,
-    "node": {
-      "__id__": 260
-    },
-    "_enabled": true,
-    "__prefab": {
-      "__id__": 340
-    },
-    "_materials": [
-      {
-        "__uuid__": "0bb50b73-023a-4269-bac6-c7be72d298d0@9b3e0"
-      }
-    ],
-    "_visFlags": 0,
-    "lightmapSettings": {
-      "__id__": 262
-    },
-    "_mesh": {
-      "__uuid__": "0bb50b73-023a-4269-bac6-c7be72d298d0@b36d2"
-    },
-    "_shadowCastingMode": 0,
-    "_shadowReceivingMode": 1,
-    "_enableMorph": true,
-    "_skeleton": {
-      "__uuid__": "0bb50b73-023a-4269-bac6-c7be72d298d0@438fe"
-    },
-    "_skinningRoot": null,
-    "_id": "fcaux/QBlGlpbXhxKWjSbP"
-  },
-  {
-    "__type__": "cc.ModelLightmapSettings",
-    "texture": null,
-    "uvParam": {
-      "__type__": "cc.Vec4",
-      "x": 0,
-      "y": 0,
-      "z": 0,
-      "w": 0
-    },
-    "_bakeable": false,
-    "_castShadow": false,
-    "_receiveShadow": false,
-    "_recieveShadow": false,
-    "_lightmapSize": 64
-  },
-  {
     "__type__": "cc.PrefabInfo",
     "root": {
-      "__id__": 258
+      "__id__": 260
     },
     "asset": {
-      "__uuid__": "a989c037-b867-498d-a666-c27bd8091361"
+      "__uuid__": "a989c037-b867-498d-a666-c27bd8091361",
+      "__expectedType__": "cc.Prefab"
     },
-    "fileId": "d29phBKDVBtYnNzkboVtys"
+    "fileId": "b5wUDRQQJJtar0+yB96lU2",
+    "instance": {
+      "__id__": 262
+    }
   },
   {
-    "__type__": "cc.Node",
-    "_name": "Bip001",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 259
-    },
-    "_children": [
+    "__type__": "cc.PrefabInstance",
+    "fileId": "15qEQ4LBxHtroUm4/j/2rP",
+    "prefabRootNode": null,
+    "mountedChildren": [],
+    "mountedComponents": [],
+    "propertyOverrides": [
+      {
+        "__id__": 263
+      },
       {
         "__id__": 265
       },
       {
         "__id__": 267
-      }
-    ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 313
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": -0.000454521155916154,
-      "y": 0.126305505633354,
-      "z": -0.00835517048835754
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": -0.5000003576277411,
-      "y": -0.4999996423720031,
-      "z": -0.4999996423720031,
-      "w": 0.5000003576277411
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 0.999999940395355,
-      "y": 0.999999940395355,
-      "z": 1
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": -90,
-      "y": -89.99991803772988,
-      "z": 0
-    },
-    "_id": "8bzN7rw/pJkaBYOU3wqDum"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip001 Footsteps",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 264
-    },
-    "_children": [],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 266
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0,
-      "y": 0,
-      "z": -0.11020639538765
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": -6.921397640638601e-34,
-      "y": 6.921406824188368e-34,
-      "z": 0.7071063043492202,
-      "w": 0.7071072580235535
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 1,
-      "z": 1
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": 0,
-      "y": -1.1216597443755499e-31,
-      "z": 90
-    },
-    "_id": "b1gKtWdmtAgr6XRD0vPEbX"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 258
-    },
-    "asset": {
-      "__uuid__": "a989c037-b867-498d-a666-c27bd8091361"
-    },
-    "fileId": "3bnfFjCsVGNZrMh0IBUSJM"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip001 Pelvis",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 264
-    },
-    "_children": [
-      {
-        "__id__": 268
-      }
-    ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 312
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0,
-      "y": 0,
-      "z": 0
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": -0.4999999925491744,
-      "y": -0.4999999925491744,
-      "z": -0.4999993070957696,
-      "w": 0.5000007078049007
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 0.999999940395355,
-      "z": 0.999999940395355
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": -89.9999197452773,
-      "y": -89.9999197452773,
-      "z": -0.0000017074910412130916
-    },
-    "_id": "a2jdcOls1GlbEx243RFROc"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip001 Spine",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 267
-    },
-    "_children": [
-      {
-        "__id__": 269
       },
-      {
-        "__id__": 279
-      },
-      {
-        "__id__": 289
-      }
-    ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 311
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.0238645933568478,
-      "y": -0.0000533515194547363,
-      "z": 3.31178284795897e-8
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": -0.0000020510958056226608,
-      "y": -7.003469966712469e-7,
-      "z": -0.056482641335319356,
-      "w": 0.9984035813352675
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 0.999999940395355,
-      "z": 0.999999940395355
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": -0.00024073200549554118,
-      "y": -0.00009400109884047531,
-      "z": -6.475880367338021
-    },
-    "_id": "3dVI5tVepLga2USHWL0Kfr"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip001 L Thigh",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 268
-    },
-    "_children": [
       {
         "__id__": 270
-      }
-    ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 278
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": -0.0237183477729559,
-      "y": -0.00263860635459423,
-      "z": 0.0198355223983526
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": -0.37561588501009924,
-      "y": 0.9258417245973276,
-      "z": -0.017228530271092765,
-      "w": -0.03785479715206737
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 0.999999940395355,
-      "z": 1.00000011920929
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": 4.808874493466241,
-      "y": -173.37516300657722,
-      "z": -43.964883085626674
-    },
-    "_id": "59q+4hjUFKr4AYxN+U/Btj"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip001 L Calf",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 269
-    },
-    "_children": [
-      {
-        "__id__": 271
-      }
-    ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 277
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.0628001317381859,
-      "y": 0,
-      "z": 2.38418573772492e-9
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": -1.0324610908159462e-18,
-      "y": -3.312262771119408e-18,
-      "z": -0.2975866783702099,
-      "w": 0.9546948040377015
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 1,
-      "z": 1.00000011920929
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": -2.7452511895869605e-16,
-      "y": -4.83141178915212e-16,
-      "z": -34.62542188876531
-    },
-    "_id": "a5DU67iRNO96PYToz7RpnJ"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip001 L Foot",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 270
-    },
-    "_children": [
+      },
       {
         "__id__": 272
+      },
+      {
+        "__id__": 274
       }
     ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 276
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.0523844808340073,
-      "y": 9.53674295089968e-9,
-      "z": -4.76837147544984e-9
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": 0.02115779587759492,
-      "y": -0.03580743872659616,
-      "z": 0.028895596471458933,
-      "w": 0.998716786436476
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 0.99999988079071,
-      "y": 0.999999940395355,
-      "z": 0.99999988079071
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": 2.544816508172388,
-      "y": -4.178323198617216,
-      "z": 3.2218247956515786
-    },
-    "_id": "e7SLbpr+hO/b5ul8TmxIU2"
+    "removedComponents": []
   },
   {
-    "__type__": "cc.Node",
-    "_name": "Bip001 L Toe0",
-    "_objFlags": 0,
-    "_parent": {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 264
+    },
+    "propertyPath": [
+      "position"
+    ],
+    "value": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 0
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "b5wUDRQQJJtar0+yB96lU2"
+    ]
+  },
+  {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 266
+    },
+    "propertyPath": [
+      "_active"
+    ],
+    "value": false
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "b5wUDRQQJJtar0+yB96lU2"
+    ]
+  },
+  {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 268
+    },
+    "propertyPath": [
+      "lightmapSettings"
+    ],
+    "value": {
+      "__id__": 269
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "ce893YtJJMcb4hRwOJwP1d"
+    ]
+  },
+  {
+    "__type__": "cc.ModelLightmapSettings",
+    "texture": null,
+    "uvParam": {
+      "__type__": "cc.Vec4",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 0
+    },
+    "_bakeable": false,
+    "_castShadow": false,
+    "_receiveShadow": false,
+    "_recieveShadow": false,
+    "_lightmapSize": 64
+  },
+  {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
       "__id__": 271
     },
-    "_children": [
-      {
-        "__id__": 273
-      }
+    "propertyPath": [
+      "_shadowReceivingMode"
     ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
+    "value": 1
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "ce893YtJJMcb4hRwOJwP1d"
+    ]
+  },
+  {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 273
+    },
+    "propertyPath": [
+      "_enableMorph"
+    ],
+    "value": true
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "ce893YtJJMcb4hRwOJwP1d"
+    ]
+  },
+  {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
       "__id__": 275
     },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.0185116957873106,
-      "y": 0.0223347507417202,
-      "z": 4.44089199923895e-18
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": -1.54542425947809e-8,
-      "y": -1.5454402466899135e-8,
-      "z": 0.7071067811865472,
-      "w": 0.7071067811865472
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 1,
-      "z": 0.999999940395355
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": 0,
-      "y": -0.0000025044672171476483,
-      "z": 90
-    },
-    "_id": "3crgpxPHlCvIdrUyub4mG1"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip001 L Toe0Nub",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 272
-    },
-    "_children": [],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 274
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.00241456506773829,
-      "y": 1.77635679969558e-17,
-      "z": 0
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": -8.70163924975861e-31,
-      "y": 1.4210854715202e-14,
-      "z": 1,
-      "w": -6.12323426292584e-17
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": -1,
-      "y": -1,
-      "z": -0.999999940395355
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": -179.99999999999838,
-      "y": -180,
-      "z": -7.016709604711002e-15
-    },
-    "_id": "07ZhZEkc9MVr/wPYcOFXnb"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 258
-    },
-    "asset": {
-      "__uuid__": "a989c037-b867-498d-a666-c27bd8091361"
-    },
-    "fileId": "1diuA6grBIPrvVimS4wHod"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 258
-    },
-    "asset": {
-      "__uuid__": "a989c037-b867-498d-a666-c27bd8091361"
-    },
-    "fileId": "5a1LEKA/tCZ4LOIocPTdbg"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 258
-    },
-    "asset": {
-      "__uuid__": "a989c037-b867-498d-a666-c27bd8091361"
-    },
-    "fileId": "11N/QwUKlOQIj71RlTf3ro"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 258
-    },
-    "asset": {
-      "__uuid__": "a989c037-b867-498d-a666-c27bd8091361"
-    },
-    "fileId": "81ELcZEhFLZ6YIIskKmhJF"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 258
-    },
-    "asset": {
-      "__uuid__": "a989c037-b867-498d-a666-c27bd8091361"
-    },
-    "fileId": "05VMHGPq1HAY9PIBIvuDCc"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip001 R Thigh",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 268
-    },
-    "_children": [
-      {
-        "__id__": 280
-      }
+    "propertyPath": [
+      "_useBakedAnimation"
     ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 288
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": -0.0237183477729559,
-      "y": -0.00263849482871592,
-      "z": -0.0198355335742235
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": 0.27701931979305616,
-      "y": 0.9606077001301917,
-      "z": -0.007359034791005917,
-      "w": 0.020952028992950077
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 1,
-      "z": 1.00000011920929
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": 1.7423098646603419,
-      "y": 176.9991689938648,
-      "z": 32.13428632439464
-    },
-    "_id": "efJcNRKBJBHLPMdb5R+86z"
+    "value": true
   },
   {
-    "__type__": "cc.Node",
-    "_name": "Bip001 R Calf",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 279
-    },
-    "_children": [
-      {
-        "__id__": 281
-      }
-    ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 287
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.0628001317381859,
-      "y": 9.53674295089968e-9,
-      "z": -4.44089199923895e-18
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": -4.389057564752536e-19,
-      "y": -6.924998941993692e-18,
-      "z": -0.06325298564200696,
-      "w": 0.9979975249505242
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 1.00000011920929,
-      "z": 1.00000011920929
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": -1.0119813664041555e-16,
-      "y": -8.015525983806116e-16,
-      "z": -7.253100268508595
-    },
-    "_id": "bdxP/4nDVJx7f8MESzemec"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip001 R Foot",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 280
-    },
-    "_children": [
-      {
-        "__id__": 282
-      }
-    ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 286
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.0523844808340073,
-      "y": -9.53674295089968e-9,
-      "z": -4.44089199923895e-18
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": -0.0035584648181420124,
-      "y": 0.02192034016134735,
-      "z": 0.022719206315045575,
-      "w": 0.9994952094331234
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1.00000011920929,
-      "y": 1.00000011920929,
-      "z": 1
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": -0.46511396961251034,
-      "y": 2.523282614427379,
-      "z": 2.5940627632125612
-    },
-    "_id": "01F5UyS4JFl5MAVfrlBhaa"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip001 R Toe0",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 281
-    },
-    "_children": [
-      {
-        "__id__": 283
-      }
-    ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 285
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.0185116976499557,
-      "y": 0.0223347656428814,
-      "z": -2.38418573772492e-9
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": -1.5454281674632067e-8,
-      "y": -1.5454342070765603e-8,
-      "z": 0.7071067811865472,
-      "w": 0.7071067811865472
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 1,
-      "z": 1
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": 0,
-      "y": -0.0000025044735503086235,
-      "z": 90
-    },
-    "_id": "cbDGDdwjtPILAOx7+giH5f"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip001 R Toe0Nub",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 282
-    },
-    "_children": [],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 284
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.00241456017829478,
-      "y": 4.76837147544984e-9,
-      "z": 2.38418573772492e-9
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": 4.2351647362715e-22,
-      "y": -1.4210854715202e-14,
-      "z": 1.49011611938477e-8,
-      "w": 1
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 1,
-      "z": 1
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": 7.279711947929809e-20,
-      "y": -1.6284439969093216e-12,
-      "z": 0.000001707547292503193
-    },
-    "_id": "12r+NxN/ZAm6H3AVNhcgd1"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 258
-    },
-    "asset": {
-      "__uuid__": "a989c037-b867-498d-a666-c27bd8091361"
-    },
-    "fileId": "6cNzbyjl9Ofrvb93N9Km+N"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 258
-    },
-    "asset": {
-      "__uuid__": "a989c037-b867-498d-a666-c27bd8091361"
-    },
-    "fileId": "3a7aO3yu5GCqut2WmVFAoj"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 258
-    },
-    "asset": {
-      "__uuid__": "a989c037-b867-498d-a666-c27bd8091361"
-    },
-    "fileId": "b2nm0Rdz9PpIgqa6xdUNbw"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 258
-    },
-    "asset": {
-      "__uuid__": "a989c037-b867-498d-a666-c27bd8091361"
-    },
-    "fileId": "0cvjFqU0VF04s0JImlF7PT"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 258
-    },
-    "asset": {
-      "__uuid__": "a989c037-b867-498d-a666-c27bd8091361"
-    },
-    "fileId": "c4SQH5KsNCpoZXvuVmAeZ8"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip001 Neck",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 268
-    },
-    "_children": [
-      {
-        "__id__": 290
-      },
-      {
-        "__id__": 294
-      },
-      {
-        "__id__": 302
-      }
-    ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 310
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.0674523040652275,
-      "y": -0.0000138056275318377,
-      "z": 0
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": 1.5700802495891315e-8,
-      "y": -7.12548117454021e-7,
-      "z": 0.24848710095367196,
-      "w": 0.9686352051516256
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 1,
-      "z": 1
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": 0.000025136346899177577,
-      "y": -0.00009074423184523803,
-      "z": 28.776009325104784
-    },
-    "_id": "e0W7TOM/9OLps/2zcveIrr"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip001 Head",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 289
-    },
-    "_children": [
-      {
-        "__id__": 291
-      }
-    ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 293
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.0197722427546978,
-      "y": 0,
-      "z": 0
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": 1.277795791417536e-8,
-      "y": 3.751551007591884e-7,
-      "z": -0.12446917269221967,
-      "w": 0.9922234753568238
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 1,
-      "z": 1
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": 0.0000070212962145069535,
-      "y": 0.000044207322133638834,
-      "z": -14.300204433565446
-    },
-    "_id": "fdloicodlC5bm1lzAmYdzx"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip001 HeadNub",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 290
-    },
-    "_children": [],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 292
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.144661858677864,
-      "y": 0,
-      "z": -6.93889374881086e-20
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": 2.48689923634717e-14,
-      "y": -1.42108530211361e-14,
-      "z": -2.77555723069065e-17,
-      "w": 1
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1.00000011920929,
-      "y": 1.00000011920929,
-      "z": 1
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": 2.849776606340005e-12,
-      "y": -1.6284438027836676e-12,
-      "z": -3.180554302352355e-15
-    },
-    "_id": "35urGP0UdLQby3rSvUudRC"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 258
-    },
-    "asset": {
-      "__uuid__": "a989c037-b867-498d-a666-c27bd8091361"
-    },
-    "fileId": "a1Y2FOEv1FIqacnT9f7Lzs"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 258
-    },
-    "asset": {
-      "__uuid__": "a989c037-b867-498d-a666-c27bd8091361"
-    },
-    "fileId": "97Vxg7Fq5Ls7M1juKMO6gu"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip001 L Clavicle",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 289
-    },
-    "_children": [
-      {
-        "__id__": 295
-      }
-    ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 301
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0,
-      "y": 0.0000157165522978175,
-      "z": 0.00611829804256558
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": 0.6225633241945363,
-      "y": -0.15997335871776505,
-      "z": 0.74194153746535,
-      "w": 0.19064675935341413
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 1,
-      "z": 1
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": 151.54728414041034,
-      "y": -98.78188043901989,
-      "z": 4.801872359886539
-    },
-    "_id": "4fqioP9O5BK666lBFlxS1F"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip001 L UpperArm",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 294
-    },
-    "_children": [
-      {
-        "__id__": 296
-      }
-    ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 300
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.0281012877821922,
-      "y": -2.38418573772492e-9,
-      "z": 1.90734859017994e-8
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": -0.16188664520403984,
-      "y": 0.496298157569867,
-      "z": -0.09664968273455293,
-      "w": 0.8474312312657865
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 1.00000011920929,
-      "z": 1
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": -10.874003078889206,
-      "y": 58.89209358135093,
-      "z": -18.935043515936034
-    },
-    "_id": "47Dr32smhBO60LhH/6YQ/L"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip001 L Forearm",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 295
-    },
-    "_children": [
-      {
-        "__id__": 297
-      }
-    ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 299
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.0665261819958687,
-      "y": 0,
-      "z": -1.77635679969558e-17
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": -3.45666603332535e-17,
-      "y": 4.3986156437027177e-17,
-      "z": -0.37611061491862924,
-      "w": 0.9265747705099306
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 1,
-      "z": 1
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": -2.4745340264225237e-15,
-      "y": 4.435415098892788e-15,
-      "z": -44.18594452228765
-    },
-    "_id": "42tsCqlNZKZZX/YyNZy7n5"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip001 L Hand",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 296
-    },
-    "_children": [],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 298
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.0509902164340019,
-      "y": -9.53674295089968e-9,
-      "z": 1.77635679969558e-17
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": -0.7068252124052272,
-      "y": 2.635226317821463e-9,
-      "z": 2.633128884436867e-9,
-      "w": 0.707388237892252
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1.00000011920929,
-      "y": 1.00000011920929,
-      "z": 1.00000023841858
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": -89.95437890588059,
-      "y": 4.2688678714193045e-7,
-      "z": -1.4325534713157562e-17
-    },
-    "_id": "d53n/jYOZMKpyOhJjX2y1Q"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 258
-    },
-    "asset": {
-      "__uuid__": "a989c037-b867-498d-a666-c27bd8091361"
-    },
-    "fileId": "658aFIs3NIsq7XSW4MkJaS"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 258
-    },
-    "asset": {
-      "__uuid__": "a989c037-b867-498d-a666-c27bd8091361"
-    },
-    "fileId": "6aRXwn5q9Ai4qLIZqTIzlS"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 258
-    },
-    "asset": {
-      "__uuid__": "a989c037-b867-498d-a666-c27bd8091361"
-    },
-    "fileId": "c0g2CTnX1JtLLK14W6rMLU"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 258
-    },
-    "asset": {
-      "__uuid__": "a989c037-b867-498d-a666-c27bd8091361"
-    },
-    "fileId": "547oJnhupKYIGeKof1qegm"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip001 R Clavicle",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 289
-    },
-    "_children": [
-      {
-        "__id__": 303
-      }
-    ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 309
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": -3.55271359939116e-17,
-      "y": 0.0000157547001435887,
-      "z": -0.00611829943954945
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": -0.614990299710438,
-      "y": 0.15802550463113116,
-      "z": 0.7482307623015274,
-      "w": 0.19226439476360957
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1.00000011920929,
-      "y": 1,
-      "z": 1.00000011920929
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": -151.63838537918068,
-      "y": 99.81030063554826,
-      "z": 5.356242587566031
-    },
-    "_id": "84KcMzBK5J56mUbvrpffaz"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip001 R UpperArm",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 302
-    },
-    "_children": [
-      {
-        "__id__": 304
-      }
-    ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 308
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.0281012915074825,
-      "y": -1.19209286886246e-9,
-      "z": -1.90734859017994e-8
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": -0.37304923561473174,
-      "y": -0.4294785630915752,
-      "z": 0.3167863839135259,
-      "w": 0.7589656241352782
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 1,
-      "z": 1
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": -29.450942000887874,
-      "y": -43.996084990506475,
-      "z": 53.25377674716975
-    },
-    "_id": "e6sQ3BeEFBXa9VN1bpv5Xb"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip001 R Forearm",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 303
-    },
-    "_children": [
-      {
-        "__id__": 305
-      }
-    ],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 307
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.0665262043476105,
-      "y": -1.90734859017994e-8,
-      "z": -4.76837147544984e-9
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": -1.5460236930107047e-18,
-      "y": -6.7644690792844786e-18,
-      "z": -0.22280552509028878,
-      "w": 0.9748629124083246
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1.00000011920929,
-      "y": 1.00000011920929,
-      "z": 1.00000011920929
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": -3.8349059761332035e-16,
-      "y": -8.827855391707161e-16,
-      "z": -25.7477372426079
-    },
-    "_id": "614IfgGZFCjrMpUAp/NosQ"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Bip001 R Hand",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 304
-    },
-    "_children": [],
-    "_active": true,
-    "_components": [],
-    "_prefab": {
-      "__id__": 306
-    },
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0.0509902164340019,
-      "y": 9.53674295089968e-9,
-      "z": 9.53674295089968e-9
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": 0.7068252124052271,
-      "y": 1.054090527128589e-8,
-      "z": -1.0532515537747486e-8,
-      "w": 0.7073882378922519
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1.00000011920929,
-      "y": 1,
-      "z": 1.00000011920929
-    },
-    "_layer": 1073741824,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": 89.95437890588059,
-      "y": 0.000001707547148567726,
-      "z": 5.730375024720206e-17
-    },
-    "_id": "23d0kVOY1CiqG3NzbF+3Yh"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 258
-    },
-    "asset": {
-      "__uuid__": "a989c037-b867-498d-a666-c27bd8091361"
-    },
-    "fileId": "19h1gnEixK+Z/m4hxhW0jK"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 258
-    },
-    "asset": {
-      "__uuid__": "a989c037-b867-498d-a666-c27bd8091361"
-    },
-    "fileId": "2aVkALktZD4rUB7IUojbD4"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 258
-    },
-    "asset": {
-      "__uuid__": "a989c037-b867-498d-a666-c27bd8091361"
-    },
-    "fileId": "54x9JMbThDnqxu4Wz8YOeS"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 258
-    },
-    "asset": {
-      "__uuid__": "a989c037-b867-498d-a666-c27bd8091361"
-    },
-    "fileId": "e14YtnzX1Bm46wY7QM5iaF"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 258
-    },
-    "asset": {
-      "__uuid__": "a989c037-b867-498d-a666-c27bd8091361"
-    },
-    "fileId": "8f99E3h+5Nk47pCnn0x9TP"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 258
-    },
-    "asset": {
-      "__uuid__": "a989c037-b867-498d-a666-c27bd8091361"
-    },
-    "fileId": "6fc/1YnjhHwa4yfzxxPbkh"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 258
-    },
-    "asset": {
-      "__uuid__": "a989c037-b867-498d-a666-c27bd8091361"
-    },
-    "fileId": "78SPadCgNMG49mUvIw42n0"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 258
-    },
-    "asset": {
-      "__uuid__": "a989c037-b867-498d-a666-c27bd8091361"
-    },
-    "fileId": "12pSgZp6BAfqJ3uhvRzoDa"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 258
-    },
-    "asset": {
-      "__uuid__": "a989c037-b867-498d-a666-c27bd8091361"
-    },
-    "fileId": "bdtbovGYxKvo8x0yMRFLdS"
-  },
-  {
-    "__type__": "cc.SkeletalAnimation",
-    "_name": "",
-    "_objFlags": 0,
-    "node": {
-      "__id__": 258
-    },
-    "_enabled": true,
-    "__prefab": {
-      "__id__": 341
-    },
-    "playOnLoad": false,
-    "_clips": [
-      {
-        "__uuid__": "b67d0ca0-77ea-4c36-bf55-9211584c367a@7f3dc"
-      }
-    ],
-    "_defaultClip": {
-      "__uuid__": "b67d0ca0-77ea-4c36-bf55-9211584c367a@7f3dc"
-    },
-    "_useBakedAnimation": true,
-    "_sockets": [],
-    "_id": "09EV3rpplK7a9UVmGQErYj"
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 258
-    },
-    "asset": {
-      "__uuid__": "a989c037-b867-498d-a666-c27bd8091361"
-    },
-    "fileId": "b5wUDRQQJJtar0+yB96lU2",
-    "instance": {
-      "__id__": 344
-    }
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "d102EzW7NDjpvDowNCrXra"
+    ]
   },
   {
     "__type__": "f0b36zMoQNHwogwqoT86U2L",
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 198
+      "__id__": 243
     },
     "_enabled": true,
     "__prefab": null,
     "customers": [
-      null,
-      null
+      {
+        "__id__": 244
+      },
+      {
+        "__id__": 260
+      }
     ],
     "walkTime": 0.2,
     "_id": "1alGcKKh1FcbqbzU+taHdC"
@@ -7237,7 +4431,7 @@
     "_active": true,
     "_components": [
       {
-        "__id__": 319
+        "__id__": 278
       }
     ],
     "_prefab": null,
@@ -7274,31 +4468,182 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 318
+      "__id__": 277
     },
     "_enabled": true,
     "__prefab": null,
     "brakeTrail": {
-      "__uuid__": "99d42ceb-66b7-4ce0-bdf1-07a97b883114"
+      "__uuid__": "99d42ceb-66b7-4ce0-bdf1-07a97b883114",
+      "__expectedType__": "cc.Prefab"
     },
     "coin": {
-      "__uuid__": "544dd404-2ec7-41d2-a45f-bec88c051fd3"
+      "__uuid__": "544dd404-2ec7-41d2-a45f-bec88c051fd3",
+      "__expectedType__": "cc.Prefab"
     },
     "_id": "b0ViDnSqpHTpLKOeXsSHDY"
   },
   {
+    "__type__": "cc.PrefabInfo",
+    "fileId": "",
+    "targetOverrides": [
+      {
+        "__id__": 280
+      },
+      {
+        "__id__": 282
+      },
+      {
+        "__id__": 284
+      },
+      {
+        "__id__": 286
+      },
+      {
+        "__id__": 289
+      }
+    ]
+  },
+  {
+    "__type__": "cc.TargetOverrideInfo",
+    "source": {
+      "__id__": 109
+    },
+    "sourceInfo": null,
+    "propertyPath": [
+      "mainCar"
+    ],
+    "target": {
+      "__id__": 111
+    },
+    "targetInfo": {
+      "__id__": 281
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "e9OFoAcAxFEIaOfLrOiAra"
+    ]
+  },
+  {
+    "__type__": "cc.TargetOverrideInfo",
+    "source": {
+      "__id__": 276
+    },
+    "sourceInfo": null,
+    "propertyPath": [
+      "customers",
+      "0"
+    ],
+    "target": {
+      "__id__": 244
+    },
+    "targetInfo": {
+      "__id__": 283
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "88g4ZyJA1IaaaiBa9sOJV/"
+    ]
+  },
+  {
+    "__type__": "cc.TargetOverrideInfo",
+    "source": {
+      "__id__": 276
+    },
+    "sourceInfo": null,
+    "propertyPath": [
+      "customers",
+      "1"
+    ],
+    "target": {
+      "__id__": 260
+    },
+    "targetInfo": {
+      "__id__": 285
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "b5wUDRQQJJtar0+yB96lU2"
+    ]
+  },
+  {
+    "__type__": "cc.TargetOverrideInfo",
+    "source": {
+      "__id__": 244
+    },
+    "sourceInfo": {
+      "__id__": 287
+    },
+    "propertyPath": [
+      "_skinningRoot"
+    ],
+    "target": {
+      "__id__": 244
+    },
+    "targetInfo": {
+      "__id__": 288
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "d9wSQXQRRBXYhff8jd0S72"
+    ]
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "88g4ZyJA1IaaaiBa9sOJV/"
+    ]
+  },
+  {
+    "__type__": "cc.TargetOverrideInfo",
+    "source": {
+      "__id__": 260
+    },
+    "sourceInfo": {
+      "__id__": 290
+    },
+    "propertyPath": [
+      "_skinningRoot"
+    ],
+    "target": {
+      "__id__": 260
+    },
+    "targetInfo": {
+      "__id__": 291
+    }
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "d102EzW7NDjpvDowNCrXra"
+    ]
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "b5wUDRQQJJtar0+yB96lU2"
+    ]
+  },
+  {
     "__type__": "cc.SceneGlobals",
     "ambient": {
-      "__id__": 321
+      "__id__": 293
     },
     "shadows": {
-      "__id__": 322
+      "__id__": 294
     },
     "_skybox": {
-      "__id__": 323
+      "__id__": 295
     },
     "fog": {
-      "__id__": 324
+      "__id__": 296
     }
   },
   {
@@ -7340,6 +4685,10 @@
     "_autoAdapt": true,
     "_pcf": 0,
     "_bias": 0.00001,
+    "_packing": false,
+    "_linear": true,
+    "_selfShadow": false,
+    "_normalBias": 0,
     "_near": 1,
     "_far": 30,
     "_aspect": 1,
@@ -7375,1274 +4724,5 @@
     "_fogAtten": 5,
     "_fogTop": 1.5,
     "_fogRange": 1.2
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "UICamera_Canvas",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 5
-    },
-    "_children": [],
-    "_active": true,
-    "_components": [
-      {
-        "__id__": 326
-      }
-    ],
-    "_prefab": null,
-    "_lpos": {
-      "__type__": "cc.Vec3",
-      "x": 0,
-      "y": 0,
-      "z": 0
-    },
-    "_lrot": {
-      "__type__": "cc.Quat",
-      "x": 0,
-      "y": 0,
-      "z": 0,
-      "w": 1
-    },
-    "_lscale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 1,
-      "z": 1
-    },
-    "_layer": 524288,
-    "_euler": {
-      "__type__": "cc.Vec3",
-      "x": 0,
-      "y": 0,
-      "z": 0
-    },
-    "_id": "588pllofdKVbpQbOPRu35n"
-  },
-  {
-    "__type__": "cc.Camera",
-    "_name": "",
-    "_objFlags": 0,
-    "node": {
-      "__id__": 325
-    },
-    "_enabled": true,
-    "__prefab": null,
-    "_projection": 0,
-    "_priority": 1073741824,
-    "_fov": 45,
-    "_fovAxis": 0,
-    "_orthoHeight": 10,
-    "_near": 1,
-    "_far": 2000,
-    "_color": {
-      "__type__": "cc.Color",
-      "r": 0,
-      "g": 0,
-      "b": 0,
-      "a": 255
-    },
-    "_depth": 1,
-    "_stencil": 0,
-    "_clearFlags": 6,
-    "_rect": {
-      "x": 0,
-      "y": 0,
-      "width": 1,
-      "height": 1
-    },
-    "_aperture": 19,
-    "_shutter": 7,
-    "_iso": 0,
-    "_screenScale": 1,
-    "_visibility": 42467328,
-    "_id": "bdFB2kAcNIU6nkiA1oWkvK"
-  },
-  {
-    "__type__": "cc.CompPrefabInfo",
-    "fileId": "55XbeWnd1F6L3uxDl7OGSV"
-  },
-  {
-    "__type__": "cc.CompPrefabInfo",
-    "fileId": "0bOAxCISxJULdbQeBkoxpu"
-  },
-  {
-    "__type__": "cc.CompPrefabInfo",
-    "fileId": "c0Gn+KDUpB+ZggnhOoP4O3"
-  },
-  {
-    "__type__": "cc.CompPrefabInfo",
-    "fileId": "e9IIo7M1VBuog3+lAOgaKe"
-  },
-  {
-    "__type__": "cc.CompPrefabInfo",
-    "fileId": "a6f9bXwTNEx75IvelmyUr3"
-  },
-  {
-    "__type__": "cc.CompPrefabInfo",
-    "fileId": "75y6AVk0BCMbDDq5CPTZ4c"
-  },
-  {
-    "__type__": "cc.CompPrefabInfo",
-    "fileId": "acqsx/XzVDc6CQ4v6LUrwq"
-  },
-  {
-    "__type__": "cc.CompPrefabInfo",
-    "fileId": "b8F9gGUz5DuI6UOnocrnRw"
-  },
-  {
-    "__type__": "cc.CompPrefabInfo",
-    "fileId": "b1HDNS/FJK0a/WSCsGBRjo"
-  },
-  {
-    "__type__": "cc.CompPrefabInfo",
-    "fileId": "b0GSHrIGpFLpCz03O2mleP"
-  },
-  {
-    "__type__": "cc.CompPrefabInfo",
-    "fileId": "1chwIrUaJOwaxPO8LjNFZv"
-  },
-  {
-    "__type__": "cc.CompPrefabInfo",
-    "fileId": "447gFDygFH2qUfw2i0gq5r"
-  },
-  {
-    "__type__": "cc.CompPrefabInfo",
-    "fileId": "d6mwlVgb5Pa6oosKDn+Aza"
-  },
-  {
-    "__type__": "cc.CompPrefabInfo",
-    "fileId": "524MG+4M5DbIOIkvXBSGJH"
-  },
-  {
-    "__type__": "cc.CompPrefabInfo",
-    "fileId": "9aR1uxmQhEdLbYxvZMDww+"
-  },
-  {
-    "__type__": "cc.PrefabInstance",
-    "fileId": "d02UgKoCFK+ZX2ElodxZEe",
-    "prefabRootNode": null,
-    "mountedChildren": [],
-    "propertyOverrides": [
-      {
-        "__id__": 346
-      },
-      {
-        "__id__": 348
-      },
-      {
-        "__id__": 350
-      },
-      {
-        "__id__": 352
-      },
-      {
-        "__id__": 354
-      },
-      {
-        "__id__": 356
-      },
-      {
-        "__id__": 358
-      },
-      {
-        "__id__": 360
-      },
-      {
-        "__id__": 362
-      },
-      {
-        "__id__": 364
-      },
-      {
-        "__id__": 366
-      },
-      {
-        "__id__": 368
-      },
-      {
-        "__id__": 370
-      },
-      {
-        "__id__": 372
-      },
-      {
-        "__id__": 374
-      },
-      {
-        "__id__": 376
-      },
-      {
-        "__id__": 378
-      },
-      {
-        "__id__": 380
-      },
-      {
-        "__id__": 382
-      },
-      {
-        "__id__": 384
-      },
-      {
-        "__id__": 386
-      },
-      {
-        "__id__": 388
-      },
-      {
-        "__id__": 390
-      },
-      {
-        "__id__": 392
-      },
-      {
-        "__id__": 394
-      },
-      {
-        "__id__": 396
-      },
-      {
-        "__id__": 398
-      },
-      {
-        "__id__": 400
-      },
-      {
-        "__id__": 402
-      },
-      {
-        "__id__": 404
-      },
-      {
-        "__id__": 406
-      },
-      {
-        "__id__": 408
-      },
-      {
-        "__id__": 410
-      },
-      {
-        "__id__": 412
-      }
-    ],
-    "removedComponents": []
-  },
-  {
-    "__type__": "cc.PrefabInstance",
-    "fileId": "f0T96nPutECbrrXd8snisz",
-    "prefabRootNode": null,
-    "mountedChildren": [],
-    "propertyOverrides": [
-      {
-        "__id__": 414
-      },
-      {
-        "__id__": 416
-      },
-      {
-        "__id__": 418
-      },
-      {
-        "__id__": 420
-      },
-      {
-        "__id__": 422
-      },
-      {
-        "__id__": 424
-      }
-    ],
-    "removedComponents": []
-  },
-  {
-    "__type__": "cc.PrefabInstance",
-    "fileId": "15qEQ4LBxHtroUm4/j/2rP",
-    "prefabRootNode": null,
-    "mountedChildren": [],
-    "propertyOverrides": [
-      {
-        "__id__": 426
-      },
-      {
-        "__id__": 428
-      },
-      {
-        "__id__": 430
-      },
-      {
-        "__id__": 432
-      },
-      {
-        "__id__": 434
-      },
-      {
-        "__id__": 436
-      }
-    ],
-    "removedComponents": []
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "9bXXwPtfJBS7AVvRYX3GGA"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 345
-    },
-    "propertyPath": [
-      "lightmapSettings"
-    ],
-    "value": {
-      "__id__": 110
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "f3kBbd969BXb+kpZKmY2KS"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 347
-    },
-    "propertyPath": [
-      "lightmapSettings"
-    ],
-    "value": {
-      "__id__": 114
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "ccznVDYfxC7oNW7gesXGx2"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 349
-    },
-    "propertyPath": [
-      "lightmapSettings"
-    ],
-    "value": {
-      "__id__": 118
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "43fXX9ZQJM9IzG45k3BGZa"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 351
-    },
-    "propertyPath": [
-      "lightmapSettings"
-    ],
-    "value": {
-      "__id__": 122
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "f7ACrawzhASrxSsW9U/pdO"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 353
-    },
-    "propertyPath": [
-      "lightmapSettings"
-    ],
-    "value": {
-      "__id__": 126
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "1dKcsLwQdHNpfVxsSO1ETD"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 355
-    },
-    "propertyPath": [
-      "lightmapSettings"
-    ],
-    "value": {
-      "__id__": 130
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "6bxqsZ6dBMVoBuLaJSiNI8"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 357
-    },
-    "propertyPath": [
-      "lightmapSettings"
-    ],
-    "value": {
-      "__id__": 135
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "fbgBe7ZvNGR4uy+r5rhU2j"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 359
-    },
-    "propertyPath": [
-      "startColor"
-    ],
-    "value": {
-      "__id__": 139
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "fbgBe7ZvNGR4uy+r5rhU2j"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 361
-    },
-    "propertyPath": [
-      "startSizeX"
-    ],
-    "value": {
-      "__id__": 140
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "fbgBe7ZvNGR4uy+r5rhU2j"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 363
-    },
-    "propertyPath": [
-      "startSize"
-    ],
-    "value": {
-      "__id__": 140
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "fbgBe7ZvNGR4uy+r5rhU2j"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 365
-    },
-    "propertyPath": [
-      "startSizeY"
-    ],
-    "value": {
-      "__id__": 141
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "fbgBe7ZvNGR4uy+r5rhU2j"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 367
-    },
-    "propertyPath": [
-      "startSizeZ"
-    ],
-    "value": {
-      "__id__": 142
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "fbgBe7ZvNGR4uy+r5rhU2j"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 369
-    },
-    "propertyPath": [
-      "startSpeed"
-    ],
-    "value": {
-      "__id__": 143
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "fbgBe7ZvNGR4uy+r5rhU2j"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 371
-    },
-    "propertyPath": [
-      "startRotationX"
-    ],
-    "value": {
-      "__id__": 144
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "fbgBe7ZvNGR4uy+r5rhU2j"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 373
-    },
-    "propertyPath": [
-      "startRotationY"
-    ],
-    "value": {
-      "__id__": 145
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "fbgBe7ZvNGR4uy+r5rhU2j"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 375
-    },
-    "propertyPath": [
-      "startRotationZ"
-    ],
-    "value": {
-      "__id__": 146
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "fbgBe7ZvNGR4uy+r5rhU2j"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 377
-    },
-    "propertyPath": [
-      "startRotation"
-    ],
-    "value": {
-      "__id__": 146
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "fbgBe7ZvNGR4uy+r5rhU2j"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 379
-    },
-    "propertyPath": [
-      "startDelay"
-    ],
-    "value": {
-      "__id__": 147
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "fbgBe7ZvNGR4uy+r5rhU2j"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 381
-    },
-    "propertyPath": [
-      "startLifetime"
-    ],
-    "value": {
-      "__id__": 148
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "fbgBe7ZvNGR4uy+r5rhU2j"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 383
-    },
-    "propertyPath": [
-      "gravityModifier"
-    ],
-    "value": {
-      "__id__": 149
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "fbgBe7ZvNGR4uy+r5rhU2j"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 385
-    },
-    "propertyPath": [
-      "rateOverTime"
-    ],
-    "value": {
-      "__id__": 150
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "fbgBe7ZvNGR4uy+r5rhU2j"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 387
-    },
-    "propertyPath": [
-      "rateOverDistance"
-    ],
-    "value": {
-      "__id__": 151
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "fbgBe7ZvNGR4uy+r5rhU2j"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 389
-    },
-    "propertyPath": [
-      "_colorOverLifetimeModule"
-    ],
-    "value": {
-      "__id__": 152
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "fbgBe7ZvNGR4uy+r5rhU2j"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 391
-    },
-    "propertyPath": [
-      "_shapeModule"
-    ],
-    "value": {
-      "__id__": 154
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "fbgBe7ZvNGR4uy+r5rhU2j"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 393
-    },
-    "propertyPath": [
-      "_sizeOvertimeModule"
-    ],
-    "value": {
-      "__id__": 156
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "fbgBe7ZvNGR4uy+r5rhU2j"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 395
-    },
-    "propertyPath": [
-      "_velocityOvertimeModule"
-    ],
-    "value": {
-      "__id__": 161
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "fbgBe7ZvNGR4uy+r5rhU2j"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 397
-    },
-    "propertyPath": [
-      "_forceOvertimeModule"
-    ],
-    "value": {
-      "__id__": 166
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "fbgBe7ZvNGR4uy+r5rhU2j"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 399
-    },
-    "propertyPath": [
-      "_limitVelocityOvertimeModule"
-    ],
-    "value": {
-      "__id__": 170
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "fbgBe7ZvNGR4uy+r5rhU2j"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 401
-    },
-    "propertyPath": [
-      "_rotationOvertimeModule"
-    ],
-    "value": {
-      "__id__": 175
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "fbgBe7ZvNGR4uy+r5rhU2j"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 403
-    },
-    "propertyPath": [
-      "_textureAnimationModule"
-    ],
-    "value": {
-      "__id__": 179
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "fbgBe7ZvNGR4uy+r5rhU2j"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 405
-    },
-    "propertyPath": [
-      "_trailModule"
-    ],
-    "value": {
-      "__id__": 182
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "fbgBe7ZvNGR4uy+r5rhU2j"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 407
-    },
-    "propertyPath": [
-      "renderer"
-    ],
-    "value": {
-      "__id__": 187
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "ebwKJd69ZPzLBWUcinaKmy"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 409
-    },
-    "propertyPath": [
-      "_group"
-    ],
-    "value": 2
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "ebwKJd69ZPzLBWUcinaKmy"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 411
-    },
-    "propertyPath": [
-      "_type"
-    ],
-    "value": 1
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "88g4ZyJA1IaaaiBa9sOJV/"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 413
-    },
-    "propertyPath": [
-      "position"
-    ],
-    "value": {
-      "__type__": "cc.Vec3",
-      "x": 0,
-      "y": 0,
-      "z": 0
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "88g4ZyJA1IaaaiBa9sOJV/"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 415
-    },
-    "propertyPath": [
-      "_active"
-    ],
-    "value": false
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "86e9p0OV1BQqlFFm6wz/P5"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 417
-    },
-    "propertyPath": [
-      "lightmapSettings"
-    ],
-    "value": {
-      "__id__": 203
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "86e9p0OV1BQqlFFm6wz/P5"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 419
-    },
-    "propertyPath": [
-      "_shadowReceivingMode"
-    ],
-    "value": 1
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "86e9p0OV1BQqlFFm6wz/P5"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 421
-    },
-    "propertyPath": [
-      "_enableMorph"
-    ],
-    "value": true
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "d9wSQXQRRBXYhff8jd0S72"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 423
-    },
-    "propertyPath": [
-      "_useBakedAnimation"
-    ],
-    "value": true
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "b5wUDRQQJJtar0+yB96lU2"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 425
-    },
-    "propertyPath": [
-      "position"
-    ],
-    "value": {
-      "__type__": "cc.Vec3",
-      "x": 0,
-      "y": 0,
-      "z": 0
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "b5wUDRQQJJtar0+yB96lU2"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 427
-    },
-    "propertyPath": [
-      "_active"
-    ],
-    "value": false
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "ce893YtJJMcb4hRwOJwP1d"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 429
-    },
-    "propertyPath": [
-      "lightmapSettings"
-    ],
-    "value": {
-      "__id__": 262
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "ce893YtJJMcb4hRwOJwP1d"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 431
-    },
-    "propertyPath": [
-      "_shadowReceivingMode"
-    ],
-    "value": 1
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "ce893YtJJMcb4hRwOJwP1d"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 433
-    },
-    "propertyPath": [
-      "_enableMorph"
-    ],
-    "value": true
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "d102EzW7NDjpvDowNCrXra"
-    ]
-  },
-  {
-    "__type__": "CCPropertyOverrideInfo",
-    "targetInfo": {
-      "__id__": 435
-    },
-    "propertyPath": [
-      "_useBakedAnimation"
-    ],
-    "value": true
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "e9OFoAcAxFEIaOfLrOiAra"
-    ]
-  },
-  {
-    "__type__": "cc.TargetOverrideInfo",
-    "source": {
-      "__id__": 104
-    },
-    "sourceInfo": null,
-    "propertyPath": [
-      "mainCar"
-    ],
-    "target": {
-      "__id__": 106
-    },
-    "targetInfo": {
-      "__id__": 437
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "88g4ZyJA1IaaaiBa9sOJV/"
-    ]
-  },
-  {
-    "__type__": "cc.TargetOverrideInfo",
-    "source": {
-      "__id__": 317
-    },
-    "sourceInfo": null,
-    "propertyPath": [
-      "customers",
-      "0"
-    ],
-    "target": {
-      "__id__": 199
-    },
-    "targetInfo": {
-      "__id__": 439
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "b5wUDRQQJJtar0+yB96lU2"
-    ]
-  },
-  {
-    "__type__": "cc.TargetOverrideInfo",
-    "source": {
-      "__id__": 317
-    },
-    "sourceInfo": null,
-    "propertyPath": [
-      "customers",
-      "1"
-    ],
-    "target": {
-      "__id__": 258
-    },
-    "targetInfo": {
-      "__id__": 441
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "d9wSQXQRRBXYhff8jd0S72"
-    ]
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "88g4ZyJA1IaaaiBa9sOJV/"
-    ]
-  },
-  {
-    "__type__": "cc.TargetOverrideInfo",
-    "source": {
-      "__id__": 199
-    },
-    "sourceInfo": {
-      "__id__": 443
-    },
-    "propertyPath": [
-      "_skinningRoot"
-    ],
-    "target": {
-      "__id__": 199
-    },
-    "targetInfo": {
-      "__id__": 444
-    }
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "d102EzW7NDjpvDowNCrXra"
-    ]
-  },
-  {
-    "__type__": "cc.TargetInfo",
-    "localID": [
-      "b5wUDRQQJJtar0+yB96lU2"
-    ]
-  },
-  {
-    "__type__": "cc.TargetOverrideInfo",
-    "source": {
-      "__id__": 258
-    },
-    "sourceInfo": {
-      "__id__": 446
-    },
-    "propertyPath": [
-      "_skinningRoot"
-    ],
-    "target": {
-      "__id__": 258
-    },
-    "targetInfo": {
-      "__id__": 447
-    }
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "targetOverrides": [
-      {
-        "__id__": 438
-      },
-      {
-        "__id__": 440
-      },
-      {
-        "__id__": 442
-      },
-      {
-        "__id__": 445
-      },
-      {
-        "__id__": 448
-      }
-    ]
   }
 ]

--- a/taxi-game/assets/script/game/GameRoot.ts
+++ b/taxi-game/assets/script/game/GameRoot.ts
@@ -1,0 +1,21 @@
+
+import { _decorator, Component, AudioSource, assert, game } from 'cc';
+import { AudioManager } from './AudioManager';
+const { ccclass, property } = _decorator;
+
+@ccclass('GameRoot')
+export class GameRoot extends Component {
+    
+    @property(AudioSource)
+    private _audioSource: AudioSource = null!;
+
+    onLoad () {
+        const audioSource = this.getComponent(AudioSource)!;
+        assert(audioSource);
+        this._audioSource = audioSource;
+        game.addPersistRootNode(this.node);
+
+        // init AudioManager
+        AudioManager.init(audioSource);
+    }
+}

--- a/taxi-game/assets/script/game/GameRoot.ts.meta
+++ b/taxi-game/assets/script/game/GameRoot.ts.meta
@@ -1,0 +1,9 @@
+{
+  "ver": "4.0.22",
+  "importer": "typescript",
+  "imported": true,
+  "uuid": "98dcd425-f068-4460-b251-1bc6a9f8487e",
+  "files": [],
+  "subMetas": {},
+  "userData": {}
+}


### PR DESCRIPTION
fix https://github.com/cocos-creator/3d-tasks/issues/7274

## changeLog
- 废弃 AudioClip 旧的用法 ( v3.1 里 AudioClip 是纯音频资源，废弃了所有播放接口)
- 增加 GameRoot 组件，并且作为持久化节点，主要用来初始化 AudioManager 模块，可以在这里初始化其他管理模块
- 场景数据的修改见下图

![scene](https://user-images.githubusercontent.com/17872773/116586171-be94db80-a94b-11eb-8ef5-184722e492c1.png)
